### PR TITLE
docs(semaphore): fix OwnedSemaphorePermit::forget doctest example

### DIFF
--- a/mea/src/semaphore/mod.rs
+++ b/mea/src/semaphore/mod.rs
@@ -555,7 +555,7 @@ impl OwnedSemaphorePermit {
     ///
     /// let sem = Arc::new(Semaphore::new(10));
     /// {
-    ///     let permit = sem.try_acquire(5).unwrap();
+    ///     let permit = sem.clone().try_acquire_owned(5).unwrap();
     ///     assert_eq!(sem.available_permits(), 5);
     ///     permit.forget();
     /// }


### PR DESCRIPTION
The original doctest for OwnedSemaphorePermit::forget used try_acquire, which returns a borrowed SemaphorePermit instead of OwnedSemaphorePermit, causing a type mismatch.