### PR TITLE
refactor(oneshot): rename is_closed to is_disconnected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Breaking changes
+
+* Rename `oneshot::Sender::is_closed` and `oneshot::Receiver::is_closed` to `is_disconnected`. ([#141](https://github.com/fast/asyncband/issues/141))
+
 ### Bug fixes
 
 * Release cancelled wait registrations promptly and reclaim fulfilled `Semaphore::forget_exact` debt nodes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Breaking changes
 
-* Rename `oneshot::Sender::is_closed` and `oneshot::Receiver::is_closed` to `is_disconnected`. ([#141](https://github.com/fast/asyncband/issues/141))
+* Rename `oneshot::Sender::is_closed` and `oneshot::Receiver::is_closed` to `is_disconnected`.
 
 ### Bug fixes
 

--- a/asyncband/src/oneshot/receiver.rs
+++ b/asyncband/src/oneshot/receiver.rs
@@ -67,12 +67,16 @@ impl<T> IntoFuture for Receiver<T> {
 }
 
 impl<T> Receiver<T> {
-    /// Returns true if the associated [`Sender`] was dropped before sending a message, or if the
-    /// message has already been received.
+    /// Returns `true` if the channel is disconnected.
     ///
-    /// If `true` is returned, all future calls to receive the message are guaranteed to return
-    /// [`RecvError`]. Future calls to this method are also guaranteed to return `true`.
-    pub fn is_closed(&self) -> bool {
+    /// The channel becomes disconnected when the associated [`Sender`] is dropped without sending
+    /// a message, or after this receiver consumes the message. A message waiting to be received
+    /// does not count as disconnected.
+    ///
+    /// If `true` is returned, all future receive operations are guaranteed to return an error, and
+    /// future calls to this method are guaranteed to return `true`. A `false` result does not
+    /// guarantee that the sender will remain connected.
+    pub fn is_disconnected(&self) -> bool {
         // SAFETY: The existence of `self` guarantees that the receiver is still alive. If the
         // sender was dropped, it observed the live receiver and left allocation cleanup to it, so
         // `channel_ptr` remains valid.

--- a/asyncband/src/oneshot/receiver.rs
+++ b/asyncband/src/oneshot/receiver.rs
@@ -69,13 +69,10 @@ impl<T> IntoFuture for Receiver<T> {
 impl<T> Receiver<T> {
     /// Returns `true` if the channel is disconnected.
     ///
-    /// The channel becomes disconnected when the associated [`Sender`] is dropped without sending
-    /// a message, or after this receiver consumes the message. A message waiting to be received
-    /// does not count as disconnected.
+    /// This occurs when the associated [`Sender`] is dropped without sending a message, or after
+    /// the message is received.
     ///
-    /// If `true` is returned, all future receive operations are guaranteed to return an error, and
-    /// future calls to this method are guaranteed to return `true`. A `false` result does not
-    /// guarantee that the sender will remain connected.
+    /// If `true` is returned, all future receive operations are guaranteed to return an error.
     pub fn is_disconnected(&self) -> bool {
         // SAFETY: The existence of `self` guarantees that the receiver is still alive. If the
         // sender was dropped, it observed the live receiver and left allocation cleanup to it, so

--- a/asyncband/src/oneshot/sender.rs
+++ b/asyncband/src/oneshot/sender.rs
@@ -116,12 +116,12 @@ impl<T> Sender<T> {
         }
     }
 
-    /// Returns `true` if the channel is disconnected because the associated receiving endpoint
-    /// has been dropped.
+    /// Returns `true` if the channel is disconnected.
+    ///
+    /// This occurs when the associated receiving endpoint is dropped.
     ///
     /// If `true` is returned, a future call to [`send`](Sender::send) is guaranteed to return an
-    /// error, and future calls to this method are guaranteed to return `true`. A `false` result
-    /// does not guarantee that the receiver will remain connected.
+    /// error.
     pub fn is_disconnected(&self) -> bool {
         // SAFETY: The channel exists on the heap for the entire duration of this method, and we
         // only ever acquire shared references to it. Note that if the receiver disconnects it

--- a/asyncband/src/oneshot/sender.rs
+++ b/asyncband/src/oneshot/sender.rs
@@ -116,10 +116,13 @@ impl<T> Sender<T> {
         }
     }
 
-    /// Returns true if the associated [`Receiver`] has been dropped.
+    /// Returns `true` if the channel is disconnected because the associated receiving endpoint
+    /// has been dropped.
     ///
-    /// If true is returned, a future call to send is guaranteed to return an error.
-    pub fn is_closed(&self) -> bool {
+    /// If `true` is returned, a future call to [`send`](Sender::send) is guaranteed to return an
+    /// error, and future calls to this method are guaranteed to return `true`. A `false` result
+    /// does not guarantee that the receiver will remain connected.
+    pub fn is_disconnected(&self) -> bool {
         // SAFETY: The channel exists on the heap for the entire duration of this method, and we
         // only ever acquire shared references to it. Note that if the receiver disconnects it
         // does not free the channel.

--- a/asyncband/src/oneshot/tests.rs
+++ b/asyncband/src/oneshot/tests.rs
@@ -44,9 +44,9 @@ fn send_before_await() {
 #[test]
 fn await_with_dropped_sender() {
     let (sender, receiver) = oneshot::channel::<u128>();
-    assert!(!receiver.is_closed());
+    assert!(!receiver.is_disconnected());
     drop(sender);
-    assert!(receiver.is_closed());
+    assert!(receiver.is_disconnected());
     assert_eq!(
         pollster::block_on(receiver),
         Err(oneshot::RecvError::Disconnected)
@@ -58,9 +58,10 @@ fn try_recv_success_then_disconnected() {
     let (tx, rx) = oneshot::channel::<i32>();
     tx.send(10).unwrap();
 
+    assert!(!rx.is_disconnected());
     assert_eq!(rx.try_recv(), Ok(10));
     assert_eq!(rx.try_recv(), Err(TryRecvError::Disconnected));
-    assert!(rx.is_closed());
+    assert!(rx.is_disconnected());
     assert!(!rx.has_message());
     assert_eq!(
         pollster::block_on(rx.into_future()),
@@ -81,8 +82,9 @@ fn send_error_preserves_message_until_consumed() {
     let (sender, receiver) = oneshot::channel();
     let (message, message_drop_count) = DropProbe::new(17u128);
 
+    assert!(!sender.is_disconnected());
     drop(receiver);
-    assert!(sender.is_closed());
+    assert!(sender.is_disconnected());
 
     let error = sender.send(message).unwrap_err();
     assert_eq!(message_drop_count.load(Ordering::Relaxed), 0);
@@ -124,7 +126,7 @@ fn dropping_unpolled_recv_closes_channel() {
 
     drop(receiver);
 
-    assert!(sender.is_closed());
+    assert!(sender.is_disconnected());
     assert_eq!(sender.send(17).unwrap_err().into_inner(), 17);
 }
 
@@ -378,7 +380,7 @@ fn poll_with_different_wakers_across_threads() {
 
     receiver_thread.join().unwrap();
     assert_eq!(WakerProbe::live_waker_count(&waker_probe1), 1);
-    assert!(sender.is_closed());
+    assert!(sender.is_disconnected());
 }
 
 #[test]
@@ -396,7 +398,7 @@ fn drop_pending_receiver_closes_channel_and_drops_waker() {
     drop(receiver);
     assert_eq!(WakerProbe::live_waker_count(&waker_probe), 1);
     assert_eq!(waker_probe.wake_count(), 0);
-    assert!(sender.is_closed());
+    assert!(sender.is_disconnected());
 
     let error = sender.send(1234).unwrap_err();
     assert_eq!(*error.as_inner(), 1234);


### PR DESCRIPTION
## Summary

- rename the oneshot Sender and Receiver predicates from is_closed to is_disconnected
- document the exact terminal conditions for both endpoints
- cover the sent-but-not-consumed receiver state and update the changelog

Closes #141

## Testing

- cargo x lint
- cargo x test --no-capture