### PR TITLE
feat: gate primitives behind feature flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
         with:
           tool: typos-cli,taplo-cli,hawkeye@7.0.0-alpha.1
       - run: cargo x lint
+      - name: Check feature matrix
+        run: cargo x check
 
   test:
     name: Run tests
@@ -58,7 +60,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-24.04, macos-14, windows-2022 ]
-        rust-version: [ "1.85.0", "stable" ]
+        rust-version: [ "1.86.0", "stable" ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Breaking changes
 
+* Make every primitive an opt-in Cargo feature and enable no primitives by default; downstream dependencies must list the primitives they use.
 * Rename `oneshot::Sender::is_closed` and `oneshot::Receiver::is_closed` to `is_disconnected`.
+* Raise the minimum supported Rust version from 1.85.0 to 1.86.0.
 
 ### Bug fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "camino"
+version = "1.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb1307f12aa967b5a58416e87b3653360e0fd614a016b6e970db08fecbb1b80d"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "122ec45a44b270afd1402f351b782c676b173e3c3fb28d86ff7ebfb4d86a4ee4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "cc"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,6 +713,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -816,6 +852,26 @@ checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1109,6 +1165,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 name = "x"
 version = "0.0.0"
 dependencies = [
+ "cargo_metadata",
  "clap",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://github.com/fast/asyncband"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/fast/asyncband"
-rust-version = "1.85.0"
+rust-version = "1.86.0"
 
 [workspace.lints.rust]
 unknown_lints = "deny"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
-[![MSRV 1.85][msrv-badge]](https://www.whatrustisit.com)
+[![MSRV 1.86][msrv-badge]](https://www.whatrustisit.com)
 [![Apache 2.0 licensed][license-badge]][license-url]
 [![Build Status][actions-badge]][actions-url]
 
@@ -13,7 +13,7 @@
 [crates-url]: https://crates.io/crates/asyncband
 [docs-badge]: https://docs.rs/asyncband/badge.svg
 [docs-url]: https://docs.rs/asyncband
-[msrv-badge]: https://img.shields.io/badge/MSRV-1.85-green?logo=rust
+[msrv-badge]: https://img.shields.io/badge/MSRV-1.86-green?logo=rust
 [license-badge]: https://img.shields.io/crates/l/asyncband
 [license-url]: LICENSE
 [actions-badge]: https://github.com/fast/asyncband/actions/workflows/ci.yml/badge.svg
@@ -23,34 +23,39 @@
 
 Asyncband is a runtime-agnostic library providing essential synchronization primitives for asynchronous Rust programming. The library offers a collection of well-tested, efficient synchronization tools that work with any async runtime.
 
-## Features
+## Available primitives
 
-* [**Barrier**](https://docs.rs/asyncband/*/asyncband/barrier/struct.Barrier.html): A synchronization primitive that enables tasks to wait until all participants arrive.
-* [**Condvar**](https://docs.rs/asyncband/*/asyncband/condvar/struct.Condvar.html): A condition variable that allows tasks to wait for a notification.
-* [**Latch**](https://docs.rs/asyncband/*/asyncband/latch/struct.Latch.html): A synchronization primitive that allows one or more tasks to wait until a set of operations completes.
-* [**Mutex**](https://docs.rs/asyncband/*/asyncband/mutex/struct.Mutex.html): A mutual exclusion primitive for protecting shared data.
-* [**Once**](https://docs.rs/asyncband/*/asyncband/once/struct.Once.html): A primitive that ensures a one-time asynchronous operation runs at most once, even when called concurrently.
-* [**OnceCell**](https://docs.rs/asyncband/*/asyncband/once/struct.OnceCell.html): A cell that can be written to at most once, providing safe, lazy initialization.
-* [**OnceMap**](https://docs.rs/asyncband/*/asyncband/once/struct.OnceMap.html): A hash map that runs computation only once for each key and stores the result.
-* [**RwLock**](https://docs.rs/asyncband/*/asyncband/rwlock/struct.RwLock.html): A reader-writer lock that allows multiple readers or a single writer at a time.
-* [**Semaphore**](https://docs.rs/asyncband/*/asyncband/semaphore/struct.Semaphore.html): A synchronization primitive that controls access to a shared resource.
-* [**WaitGroup**](https://docs.rs/asyncband/*/asyncband/waitgroup/struct.WaitGroup.html): A synchronization primitive that allows waiting for multiple tasks to complete.
-* [**admission::FairShare**](https://docs.rs/asyncband/*/asyncband/admission/struct.FairShare.html): A work-conserving admission policy that fairly shares bounded concurrency across keys.
-* [**atomicbox**](https://docs.rs/asyncband/*/asyncband/atomicbox/): A safe, owning version of AtomicPtr for heap-allocated data.
-* [**broadcast**](https://docs.rs/asyncband/*/asyncband/broadcast/): A multi-producer, multi-consumer broadcast channel.
-* [**mpsc::bounded**](https://docs.rs/asyncband/*/asyncband/mpsc/fn.bounded.html): A multi-producer, single-consumer bounded queue for sending values between asynchronous tasks.
-* [**mpsc::unbounded**](https://docs.rs/asyncband/*/asyncband/mpsc/fn.unbounded.html): A multi-producer, single-consumer unbounded queue for sending values between asynchronous tasks.
-* [**oneshot::channel**](https://docs.rs/asyncband/*/asyncband/oneshot/): A one-shot channel for sending a single value between tasks.
-* [**shutdown**](https://docs.rs/asyncband/*/asyncband/shutdown/): A composite synchronization primitive for managing shutdown signals.
-* [**singleflight::Group**](https://docs.rs/asyncband/*/asyncband/singleflight/): A duplicate function call suppression mechanism.
+Each module is an opt-in Cargo feature. The crate enables no primitives by default.
+
+| Feature | Main API | Purpose |
+| --- | --- | --- |
+| `admission` | [`FairShare`](https://docs.rs/asyncband/*/asyncband/admission/struct.FairShare.html) | Fairly share bounded concurrency across keys. |
+| `atomicbox` | [`AtomicBox`](https://docs.rs/asyncband/*/asyncband/atomicbox/struct.AtomicBox.html), [`AtomicOptionBox`](https://docs.rs/asyncband/*/asyncband/atomicbox/struct.AtomicOptionBox.html) | Own heap-allocated values behind atomic pointers. |
+| `barrier` | [`Barrier`](https://docs.rs/asyncband/*/asyncband/barrier/struct.Barrier.html) | Wait until all participants reach a synchronization point. |
+| `broadcast` | [`broadcast::overflow`](https://docs.rs/asyncband/*/asyncband/broadcast/overflow/) | Send each value to multiple receivers. |
+| `condvar` | [`Condvar`](https://docs.rs/asyncband/*/asyncband/condvar/struct.Condvar.html) | Wait for notifications while releasing a mutex. |
+| `latch` | [`Latch`](https://docs.rs/asyncband/*/asyncband/latch/struct.Latch.html) | Wait until a one-way countdown completes. |
+| `mpsc` | [`bounded`](https://docs.rs/asyncband/*/asyncband/mpsc/fn.bounded.html), [`unbounded`](https://docs.rs/asyncband/*/asyncband/mpsc/fn.unbounded.html) | Send values from multiple producers to one consumer. |
+| `mutex` | [`Mutex`](https://docs.rs/asyncband/*/asyncband/mutex/struct.Mutex.html) | Protect shared data with asynchronous mutual exclusion. |
+| `once` | [`Once`](https://docs.rs/asyncband/*/asyncband/once/struct.Once.html), [`OnceCell`](https://docs.rs/asyncband/*/asyncband/once/struct.OnceCell.html), [`OnceMap`](https://docs.rs/asyncband/*/asyncband/once/struct.OnceMap.html) | Coordinate one-time asynchronous initialization. |
+| `oneshot` | [`oneshot::channel`](https://docs.rs/asyncband/*/asyncband/oneshot/fn.channel.html) | Send one value between two tasks. |
+| `rwlock` | [`RwLock`](https://docs.rs/asyncband/*/asyncband/rwlock/struct.RwLock.html) | Allow multiple readers or one writer. |
+| `semaphore` | [`Semaphore`](https://docs.rs/asyncband/*/asyncband/semaphore/struct.Semaphore.html) | Control concurrent access with permits. |
+| `shutdown` | [`shutdown`](https://docs.rs/asyncband/*/asyncband/shutdown/) | Coordinate shutdown signals and completion. |
+| `singleflight` | [`Group`](https://docs.rs/asyncband/*/asyncband/singleflight/struct.Group.html) | Coalesce concurrent calls for the same key. |
+| `waitgroup` | [`WaitGroup`](https://docs.rs/asyncband/*/asyncband/waitgroup/struct.WaitGroup.html) | Wait for a dynamic group of tasks to finish. |
+
+Features that build on other primitives enable them automatically: `condvar` enables `mutex`, `mpsc` enables `atomicbox`, `once` enables `semaphore`, `shutdown` enables `latch` and `waitgroup`, and `singleflight` enables `once`.
 
 ## Installation
 
 Add the dependency to your `Cargo.toml` via:
 
 ```shell
-cargo add asyncband
+cargo add asyncband --features mutex,oneshot
 ```
+
+List every primitive your application uses in `features`; a bare `cargo add asyncband` intentionally exposes no primitive modules.
 
 ## Migrating from MEA
 
@@ -68,7 +73,7 @@ Asyncband primitives and guards implement `Send` and `Sync` only when the protec
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is built against the latest stable release, and its minimum supported rustc version is 1.85.0.
+This crate is built against the latest stable release, and its minimum supported rustc version is 1.86.0.
 
 The policy is that the minimum Rust version required to use this crate can be increased in minor version updates. For example, if Asyncband 1.0 requires Rust 1.20.0, then Asyncband 1.0.z for all values of z will also require Rust 1.20.0 or newer. However, Asyncband 1.y for y > 0 may require a newer minimum version of Rust.
 

--- a/asyncband/Cargo.toml
+++ b/asyncband/Cargo.toml
@@ -35,10 +35,30 @@ rust-version.workspace = true
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[features]
+default = []
+
+# Each primitive has its own feature, so users can opt in to only what they need.
+admission = []
+atomicbox = []
+barrier = []
+broadcast = []
+condvar = ["mutex"]
+latch = []
+mpsc = ["atomicbox"]
+mutex = []
+once = ["dep:hashbrown", "semaphore"]
+oneshot = []
+rwlock = []
+semaphore = []
+shutdown = ["latch", "waitgroup"]
+singleflight = ["once"]
+waitgroup = []
+
 [dependencies]
 hashbrown = { version = "0.17.1", default-features = false, features = [
   "inline-more",
-] }
+], optional = true }
 
 [dev-dependencies]
 divan = { version = "0.1.21" }
@@ -50,6 +70,23 @@ tokio-test = { version = "0.4.5" }
 harness = false
 name = "primitives"
 path = "benches/primitives/main.rs"
+required-features = [
+  "admission",
+  "atomicbox",
+  "barrier",
+  "broadcast",
+  "condvar",
+  "latch",
+  "mpsc",
+  "mutex",
+  "once",
+  "oneshot",
+  "rwlock",
+  "semaphore",
+  "shutdown",
+  "singleflight",
+  "waitgroup",
+]
 
 [lints]
 workspace = true

--- a/asyncband/src/internal/mod.rs
+++ b/asyncband/src/internal/mod.rs
@@ -15,26 +15,136 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#[cfg(any(
+    feature = "admission",
+    feature = "barrier",
+    feature = "broadcast",
+    feature = "condvar",
+    feature = "latch",
+    feature = "mpsc",
+    feature = "mutex",
+    feature = "once",
+    feature = "rwlock",
+    feature = "semaphore",
+    feature = "singleflight",
+    feature = "waitgroup",
+))]
+// Individual primitives intentionally use different subsets of this shared storage helper.
+#[allow(dead_code)]
 mod arena;
+#[cfg(any(
+    feature = "admission",
+    feature = "barrier",
+    feature = "broadcast",
+    feature = "condvar",
+    feature = "latch",
+    feature = "mpsc",
+    feature = "mutex",
+    feature = "once",
+    feature = "rwlock",
+    feature = "semaphore",
+    feature = "singleflight",
+    feature = "waitgroup",
+))]
 pub(crate) use arena::*;
 
+#[cfg(any(feature = "latch", feature = "once", feature = "waitgroup"))]
+// Latches, once values, and wait groups use different countdown transitions.
+#[allow(dead_code)]
 mod countdown;
+#[cfg(any(feature = "latch", feature = "once", feature = "waitgroup"))]
 pub(crate) use countdown::*;
 
+#[cfg(any(feature = "once", feature = "singleflight"))]
 mod once_table;
+#[cfg(any(feature = "once", feature = "singleflight"))]
 pub(crate) use once_table::*;
 
+#[cfg(any(
+    feature = "admission",
+    feature = "barrier",
+    feature = "broadcast",
+    feature = "condvar",
+    feature = "latch",
+    feature = "mpsc",
+    feature = "mutex",
+    feature = "once",
+    feature = "rwlock",
+    feature = "semaphore",
+    feature = "singleflight",
+    feature = "waitgroup",
+))]
 mod mutex;
+#[cfg(any(
+    feature = "admission",
+    feature = "barrier",
+    feature = "broadcast",
+    feature = "condvar",
+    feature = "latch",
+    feature = "mpsc",
+    feature = "mutex",
+    feature = "once",
+    feature = "rwlock",
+    feature = "semaphore",
+    feature = "singleflight",
+    feature = "waitgroup",
+))]
 pub(crate) use mutex::*;
 
+#[cfg(feature = "broadcast")]
 mod rwlock;
+#[cfg(feature = "broadcast")]
 pub(crate) use rwlock::*;
 
+#[cfg(any(
+    feature = "mpsc",
+    feature = "mutex",
+    feature = "rwlock",
+    feature = "semaphore",
+))]
+// Public primitives expose different subsets of the internal semaphore operations.
+#[allow(dead_code)]
 mod semaphore;
+#[cfg(any(
+    feature = "mpsc",
+    feature = "mutex",
+    feature = "rwlock",
+    feature = "semaphore",
+))]
 pub(crate) use semaphore::*;
 
+#[cfg(any(
+    feature = "condvar",
+    feature = "mpsc",
+    feature = "mutex",
+    feature = "rwlock",
+    feature = "semaphore",
+))]
 mod waitlist;
+#[cfg(any(
+    feature = "condvar",
+    feature = "mpsc",
+    feature = "mutex",
+    feature = "rwlock",
+    feature = "semaphore",
+))]
 pub(crate) use waitlist::*;
 
+#[cfg(any(
+    feature = "barrier",
+    feature = "broadcast",
+    feature = "latch",
+    feature = "once",
+    feature = "waitgroup",
+))]
+// Individual primitives construct and inspect wait sets through different entry points.
+#[allow(dead_code)]
 mod waitset;
+#[cfg(any(
+    feature = "barrier",
+    feature = "broadcast",
+    feature = "latch",
+    feature = "once",
+    feature = "waitgroup",
+))]
 pub(crate) use waitset::*;

--- a/asyncband/src/internal/mod.rs
+++ b/asyncband/src/internal/mod.rs
@@ -29,7 +29,8 @@
     feature = "singleflight",
     feature = "waitgroup",
 ))]
-// Individual primitives intentionally use different subsets of this shared storage helper.
+// `admission`, `WaitList`, and `WaitSet` use different `Arena` operations. A single-primitive
+// build therefore leaves part of this shared API unused, while the all-feature build uses it.
 #[allow(dead_code)]
 mod arena;
 #[cfg(any(
@@ -49,7 +50,8 @@ mod arena;
 pub(crate) use arena::*;
 
 #[cfg(any(feature = "latch", feature = "once", feature = "waitgroup"))]
-// Latches, once values, and wait groups use different countdown transitions.
+// `waitgroup` increments and decrements the countdown, while `latch` and `once` only decrement it.
+// Consequently, `increment` is unused when either of the latter features is built alone.
 #[allow(dead_code)]
 mod countdown;
 #[cfg(any(feature = "latch", feature = "once", feature = "waitgroup"))]
@@ -102,7 +104,9 @@ pub(crate) use rwlock::*;
     feature = "rwlock",
     feature = "semaphore",
 ))]
-// Public primitives expose different subsets of the internal semaphore operations.
+// `mpsc` uses `poll_acquire`, `release_if_nonempty`, and `notify_all`; mutexes and rwlocks use
+// `acquire`, `try_acquire`, and `release`; the public semaphore also uses the accounting methods.
+// Each single-primitive build intentionally leaves the other groups unused.
 #[allow(dead_code)]
 mod semaphore;
 #[cfg(any(
@@ -137,7 +141,8 @@ pub(crate) use waitlist::*;
     feature = "once",
     feature = "waitgroup",
 ))]
-// Individual primitives construct and inspect wait sets through different entry points.
+// `barrier` constructs a wait set with `with_capacity`, while broadcast and countdown-based
+// primitives use `new`. One constructor is therefore unused in every single-primitive build.
 #[allow(dead_code)]
 mod waitset;
 #[cfg(any(

--- a/asyncband/src/lib.rs
+++ b/asyncband/src/lib.rs
@@ -69,49 +69,34 @@
 mod internal;
 
 #[cfg(feature = "admission")]
-#[cfg_attr(docsrs, doc(cfg(feature = "admission")))]
 pub mod admission;
 #[cfg(feature = "atomicbox")]
-#[cfg_attr(docsrs, doc(cfg(feature = "atomicbox")))]
 pub mod atomicbox;
 #[cfg(feature = "barrier")]
-#[cfg_attr(docsrs, doc(cfg(feature = "barrier")))]
 pub mod barrier;
 #[cfg(feature = "broadcast")]
-#[cfg_attr(docsrs, doc(cfg(feature = "broadcast")))]
 pub mod broadcast;
 #[cfg(feature = "condvar")]
-#[cfg_attr(docsrs, doc(cfg(feature = "condvar")))]
 pub mod condvar;
 #[cfg(feature = "latch")]
-#[cfg_attr(docsrs, doc(cfg(feature = "latch")))]
 pub mod latch;
 #[cfg(feature = "mpsc")]
-#[cfg_attr(docsrs, doc(cfg(feature = "mpsc")))]
 pub mod mpsc;
 #[cfg(feature = "mutex")]
-#[cfg_attr(docsrs, doc(cfg(feature = "mutex")))]
 pub mod mutex;
 #[cfg(feature = "once")]
-#[cfg_attr(docsrs, doc(cfg(feature = "once")))]
 pub mod once;
 #[cfg(feature = "oneshot")]
-#[cfg_attr(docsrs, doc(cfg(feature = "oneshot")))]
 pub mod oneshot;
 #[cfg(feature = "rwlock")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rwlock")))]
 pub mod rwlock;
 #[cfg(feature = "semaphore")]
-#[cfg_attr(docsrs, doc(cfg(feature = "semaphore")))]
 pub mod semaphore;
 #[cfg(feature = "shutdown")]
-#[cfg_attr(docsrs, doc(cfg(feature = "shutdown")))]
 pub mod shutdown;
 #[cfg(feature = "singleflight")]
-#[cfg_attr(docsrs, doc(cfg(feature = "singleflight")))]
 pub mod singleflight;
 #[cfg(feature = "waitgroup")]
-#[cfg_attr(docsrs, doc(cfg(feature = "waitgroup")))]
 pub mod waitgroup;
 
 #[cfg(all(doctest, feature = "mutex", feature = "rwlock"))]

--- a/asyncband/src/lib.rs
+++ b/asyncband/src/lib.rs
@@ -28,31 +28,17 @@
 //! compatibility crate or re-export is provided. Replace the `mea` dependency with `asyncband` and
 //! update `mea::` paths to `asyncband::`.
 //!
-//! # Features
+//! # Cargo features
 //!
-//! * [`Barrier`]: A synchronization point where multiple tasks can wait until all participants
-//!   arrive
-//! * [`Condvar`]: A condition variable that allows tasks to wait for a notification
-//! * [`Latch`]: A single-use barrier that allows one or more tasks to wait until a signal is given
-//! * [`Mutex`]: A mutual exclusion primitive for protecting shared data
-//! * [`Once`]: A primitive that ensures a one-time asynchronous operation runs at most once, even
-//!   when called concurrently
-//! * [`OnceCell`]: A cell that can be written to at most once and provides safe concurrent access
-//! * [`OnceMap`]: A hash map that runs computation only once for each key and stores the result.
-//! * [`RwLock`]: A reader-writer lock that allows multiple readers or a single writer at a time
-//! * [`Semaphore`]: A synchronization primitive that controls access to a shared resource
-//! * [`WaitGroup`]: A synchronization primitive that allows waiting for multiple tasks to complete
-//! * [`admission::FairShare`]: A work-conserving admission policy that fairly shares bounded
-//!   concurrency across keys
-//! * [`atomicbox`]: A safe, owning version of `AtomicPtr` for heap-allocated data.
-//! * [`broadcast`]: A multi-producer, multi-consumer broadcast channel.
-//! * [`mpsc::bounded`]: A multi-producer, single-consumer bounded queue for sending values between
-//!   asynchronous tasks.
-//! * [`mpsc::unbounded`]: A multi-producer, single-consumer unbounded queue for sending values
-//!   between asynchronous tasks.
-//! * [`oneshot::channel`]: A one-shot channel for sending a single value between tasks.
-//! * [`shutdown`]: A composite synchronization primitive for managing shutdown signals.
-//! * [`singleflight::Group`]: A duplicate function call suppression mechanism.
+//! The crate enables no primitives by default. Each public module has a same-named opt-in feature,
+//! so applications only compile the primitives they use:
+//!
+//! ```toml
+//! asyncband = { version = "0.7", features = ["mutex", "oneshot"] }
+//! ```
+//!
+//! Features that build on other primitives enable those dependencies automatically. For example,
+//! `condvar` enables `mutex`, while `shutdown` enables `latch` and `waitgroup`.
 //!
 //! # Runtime Agnostic
 //!
@@ -66,40 +52,81 @@
 //! transferred value satisfies the necessary bounds. In particular, owned read guards that may move
 //! destruction to another thread require the protected value to be `Send` as well as `Sync`. See
 //! each type's documentation for its exact bounds.
-//!
-//! [`Barrier`]: barrier::Barrier
-//! [`Condvar`]: condvar::Condvar
-//! [`Latch`]: latch::Latch
-//! [`Mutex`]: mutex::Mutex
-//! [`Once`]: once::Once
-//! [`OnceCell`]: once::OnceCell
-//! [`OnceMap`]: once::OnceMap
-//! [`RwLock`]: rwlock::RwLock
-//! [`Semaphore`]: semaphore::Semaphore
-//! [`WaitGroup`]: waitgroup::WaitGroup
-
+#[cfg(any(
+    feature = "admission",
+    feature = "barrier",
+    feature = "broadcast",
+    feature = "condvar",
+    feature = "latch",
+    feature = "mpsc",
+    feature = "mutex",
+    feature = "once",
+    feature = "rwlock",
+    feature = "semaphore",
+    feature = "singleflight",
+    feature = "waitgroup",
+))]
 mod internal;
 
+#[cfg(feature = "admission")]
+#[cfg_attr(docsrs, doc(cfg(feature = "admission")))]
 pub mod admission;
+#[cfg(feature = "atomicbox")]
+#[cfg_attr(docsrs, doc(cfg(feature = "atomicbox")))]
 pub mod atomicbox;
+#[cfg(feature = "barrier")]
+#[cfg_attr(docsrs, doc(cfg(feature = "barrier")))]
 pub mod barrier;
+#[cfg(feature = "broadcast")]
+#[cfg_attr(docsrs, doc(cfg(feature = "broadcast")))]
 pub mod broadcast;
+#[cfg(feature = "condvar")]
+#[cfg_attr(docsrs, doc(cfg(feature = "condvar")))]
 pub mod condvar;
+#[cfg(feature = "latch")]
+#[cfg_attr(docsrs, doc(cfg(feature = "latch")))]
 pub mod latch;
+#[cfg(feature = "mpsc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "mpsc")))]
 pub mod mpsc;
+#[cfg(feature = "mutex")]
+#[cfg_attr(docsrs, doc(cfg(feature = "mutex")))]
 pub mod mutex;
+#[cfg(feature = "once")]
+#[cfg_attr(docsrs, doc(cfg(feature = "once")))]
 pub mod once;
+#[cfg(feature = "oneshot")]
+#[cfg_attr(docsrs, doc(cfg(feature = "oneshot")))]
 pub mod oneshot;
+#[cfg(feature = "rwlock")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rwlock")))]
 pub mod rwlock;
+#[cfg(feature = "semaphore")]
+#[cfg_attr(docsrs, doc(cfg(feature = "semaphore")))]
 pub mod semaphore;
+#[cfg(feature = "shutdown")]
+#[cfg_attr(docsrs, doc(cfg(feature = "shutdown")))]
 pub mod shutdown;
+#[cfg(feature = "singleflight")]
+#[cfg_attr(docsrs, doc(cfg(feature = "singleflight")))]
 pub mod singleflight;
+#[cfg(feature = "waitgroup")]
+#[cfg_attr(docsrs, doc(cfg(feature = "waitgroup")))]
 pub mod waitgroup;
 
-#[cfg(doctest)]
+#[cfg(all(doctest, feature = "mutex", feature = "rwlock"))]
 pub mod guard_variance_tests;
 
-#[cfg(test)]
+#[cfg(all(
+    test,
+    any(
+        feature = "condvar",
+        feature = "mpsc",
+        feature = "once",
+        feature = "shutdown",
+        feature = "waitgroup",
+    )
+))]
 fn test_runtime() -> &'static tokio::runtime::Runtime {
     use std::sync::OnceLock;
 
@@ -108,7 +135,15 @@ fn test_runtime() -> &'static tokio::runtime::Runtime {
     RT.get_or_init(|| Runtime::new().unwrap())
 }
 
-#[cfg(test)]
+#[cfg(all(
+    test,
+    any(
+        feature = "admission",
+        feature = "condvar",
+        feature = "once",
+        feature = "singleflight",
+    )
+))]
 pub(crate) fn poll_once<F: std::future::Future>(
     future: std::pin::Pin<&mut F>,
 ) -> std::task::Poll<F::Output> {
@@ -116,7 +151,24 @@ pub(crate) fn poll_once<F: std::future::Future>(
     future.poll(&mut context)
 }
 
-#[cfg(test)]
+#[cfg(all(
+    test,
+    feature = "admission",
+    feature = "atomicbox",
+    feature = "barrier",
+    feature = "broadcast",
+    feature = "condvar",
+    feature = "latch",
+    feature = "mpsc",
+    feature = "mutex",
+    feature = "once",
+    feature = "oneshot",
+    feature = "rwlock",
+    feature = "semaphore",
+    feature = "shutdown",
+    feature = "singleflight",
+    feature = "waitgroup",
+))]
 mod tests {
     use crate::admission::FairShare;
     use crate::admission::FairSharePermit;

--- a/asyncband/src/mutex/mod.rs
+++ b/asyncband/src/mutex/mod.rs
@@ -291,6 +291,7 @@ pub struct MutexGuard<'a, T: ?Sized> {
     lock: &'a Mutex<T>,
 }
 
+#[cfg(feature = "condvar")]
 pub(crate) fn guard_lock<'a, T: ?Sized>(guard: &MutexGuard<'a, T>) -> &'a Mutex<T> {
     guard.lock
 }
@@ -470,6 +471,7 @@ pub struct OwnedMutexGuard<T: ?Sized> {
     lock: Arc<Mutex<T>>,
 }
 
+#[cfg(feature = "condvar")]
 pub(crate) fn owned_guard_lock<T: ?Sized>(guard: &OwnedMutexGuard<T>) -> Arc<Mutex<T>> {
     guard.lock.clone()
 }

--- a/asyncband/src/once/once/tests.rs
+++ b/asyncband/src/once/once/tests.rs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
@@ -23,7 +22,6 @@ use std::time::Duration;
 use tokio_test::assert_ready;
 
 use super::*;
-use crate::latch::Latch;
 use crate::test_runtime;
 
 #[tokio::test]
@@ -58,21 +56,16 @@ fn test_once_multi_task() {
     test_runtime().block_on(async {
         const N: usize = 100;
 
-        let latch = Arc::new(Latch::new(N as u32));
         let mut handles = Vec::with_capacity(N);
 
         for _ in 0..N {
-            let latch = latch.clone();
             handles.push(tokio::spawn(async move {
                 ONCE.call_once(async || {
                     COUNTER.fetch_add(1, Ordering::SeqCst);
                 })
                 .await;
-                latch.count_down();
             }));
         }
-
-        latch.wait().await;
 
         for handle in handles {
             handle.await.unwrap();

--- a/asyncband/src/once/once_cell/tests.rs
+++ b/asyncband/src/once/once_cell/tests.rs
@@ -23,7 +23,6 @@ use std::time::Duration;
 use tokio::sync::Mutex;
 
 use super::*;
-use crate::latch::Latch;
 
 struct Foo {
     value: Arc<AtomicBool>,
@@ -78,21 +77,21 @@ fn multi_init() {
     rt.block_on(async {
         const N: usize = 100;
 
-        let latch = Arc::new(Latch::new(N as u32));
         let values = Arc::new(Mutex::new(vec![0; N]));
+        let mut handles = Vec::with_capacity(N);
 
         for i in 0..N {
-            let latch = latch.clone();
             let values = values.clone();
-            rt.spawn(async move {
+            handles.push(rt.spawn(async move {
                 let result = CELL.get_or_init(move || async move { i + 1000 }).await;
                 let mut values = values.lock().await;
                 values[i] = *result;
-                latch.count_down();
-            });
+            }));
         }
 
-        latch.wait().await;
+        for handle in handles {
+            handle.await.unwrap();
+        }
         let cell_value = CELL.get().unwrap();
         for (index, value) in values.lock().await.iter().enumerate() {
             assert_eq!(*value, *cell_value, "mismatch at index {index}");

--- a/asyncband/src/semaphore/tests.rs
+++ b/asyncband/src/semaphore/tests.rs
@@ -23,7 +23,6 @@ use std::task::Waker;
 use std::vec::Vec;
 
 use super::*;
-use crate::latch::Latch;
 
 #[test]
 fn no_permits() {
@@ -205,21 +204,21 @@ async fn acquire_then_forget_exact() {
     s.forget_exact(3);
     assert_eq!(s.available_permits(), 2);
 
-    let acquired = Arc::new(Latch::new(1));
+    let (acquired_tx, mut acquired_rx) = tokio::sync::oneshot::channel();
 
-    let acquired_clone = acquired.clone();
     let s_clone = s.clone();
     tokio::spawn(async move {
-        let _p = s_clone.acquire(3).await;
-        acquired_clone.count_down();
+        let permit = s_clone.acquire(3).await;
+        drop(permit);
+        acquired_tx.send(()).unwrap();
     });
-    assert!(acquired.try_wait().is_err());
+    assert!(acquired_rx.try_recv().is_err());
 
     s.forget_exact(2);
     s.release(2);
-    assert!(acquired.try_wait().is_err());
+    assert!(acquired_rx.try_recv().is_err());
 
     s.release(1);
-    acquired.wait().await;
+    acquired_rx.await.unwrap();
     assert_eq!(s.available_permits(), 3);
 }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -30,6 +30,7 @@ rust-version.workspace = true
 release = false
 
 [dependencies]
+cargo_metadata = { version = "0.23.1" }
 clap = { version = "4.6.5", features = ["derive"] }
 semver = { version = "1.0.28" }
 serde = { version = "1.0.229", features = ["derive"] }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::path::Path;
 use std::process::Command as StdCommand;
 use std::time::Duration;
 
@@ -36,6 +37,7 @@ impl Command {
         match self.sub {
             SubCommand::Bench(cmd) => cmd.run(),
             SubCommand::Build(cmd) => cmd.run(),
+            SubCommand::Check(cmd) => cmd.run(),
             SubCommand::Lint(cmd) => cmd.run(),
             SubCommand::Semver(cmd) => cmd.run(),
             SubCommand::Test(cmd) => cmd.run(),
@@ -49,6 +51,8 @@ enum SubCommand {
     Bench(CommandBench),
     #[clap(about = "Compile workspace packages.")]
     Build(CommandBuild),
+    #[clap(about = "Check asyncband under the feature matrix.")]
+    Check(CommandCheck),
     #[clap(about = "Run workspace quality checks.")]
     Lint(CommandLint),
     #[clap(about = "Verify API compatibility for a planned release.")]
@@ -79,6 +83,21 @@ impl CommandBuild {
 }
 
 #[derive(Parser)]
+struct CommandCheck;
+
+impl CommandCheck {
+    fn run(self) {
+        let features = asyncband_features();
+
+        run_command(make_check_cmd(&[]));
+        for feature in features.chunks(1) {
+            run_command(make_check_cmd(feature));
+        }
+        run_command(make_check_cmd(&features));
+    }
+}
+
+#[derive(Parser)]
 struct CommandTest {
     #[arg(long, help = "Run tests serially and do not capture output.")]
     no_capture: bool,
@@ -86,8 +105,31 @@ struct CommandTest {
 
 impl CommandTest {
     fn run(self) {
-        run_command(make_test_cmd(self.no_capture, &[]));
+        run_command(make_test_cmd(self.no_capture, &asyncband_features()));
     }
+}
+
+fn asyncband_features() -> Vec<String> {
+    use cargo_metadata::Metadata;
+    use cargo_metadata::MetadataCommand;
+
+    let manifest = Path::new(env!("CARGO_WORKSPACE_DIR")).join("Cargo.toml");
+    let Metadata { packages, .. } = MetadataCommand::new()
+        .manifest_path(manifest)
+        .exec()
+        .expect("failed to get cargo metadata");
+    let package = packages
+        .into_iter()
+        .find(|package| package.name == PACKAGE_NAME)
+        .expect("failed to find asyncband package");
+
+    let mut features = package
+        .features
+        .into_keys()
+        .filter(|feature| feature != "default")
+        .collect::<Vec<_>>();
+    features.sort();
+    features
 }
 
 #[derive(Parser)]
@@ -243,7 +285,7 @@ fn classify_release_type(baseline: &Version, release: &Version) -> SemverRelease
 
 fn make_bench_cmd() -> StdCommand {
     let mut cmd = find_command("cargo");
-    cmd.args(["bench", "--workspace", "--bench", "*"]);
+    cmd.args(["bench", "--workspace", "--all-features", "--bench", "*"]);
     cmd
 }
 
@@ -264,14 +306,31 @@ fn make_build_cmd(locked: bool) -> StdCommand {
     cmd
 }
 
-fn make_test_cmd(no_capture: bool, features: &[&str]) -> StdCommand {
+fn make_test_cmd(no_capture: bool, features: &[String]) -> StdCommand {
     let mut cmd = find_command("cargo");
     cmd.args(["test", "--workspace", "--no-default-features"]);
-    if !features.is_empty() {
-        cmd.args(["--features", features.join(",").as_str()]);
+    for feature in features {
+        cmd.args(["--features", feature]);
     }
     if no_capture {
         cmd.args(["--", "--nocapture"]);
+    }
+    cmd
+}
+
+fn make_check_cmd(features: &[String]) -> StdCommand {
+    let mut cmd = find_command("cargo");
+    cmd.env("RUSTFLAGS", "-Dwarnings");
+    cmd.args([
+        "+nightly",
+        "check",
+        "--package",
+        PACKAGE_NAME,
+        "--all-targets",
+        "--no-default-features",
+    ]);
+    for feature in features {
+        cmd.args(["--features", feature]);
     }
     cmd
 }


### PR DESCRIPTION
## Summary

- Make every public primitive module an opt-in Cargo feature and keep `default = []`.
- Encode feature dependencies between composite primitives and make `hashbrown` optional for the `once` and `singleflight` paths.
- Gate shared internal modules, tests, docs, and benchmarks so zero-feature, individual-feature, and all-feature builds remain clean.
- Add an xtask/CI feature matrix modeled after DataSketches Rust and document feature selection for users.

## Breaking changes

- Downstream users must explicitly enable every primitive they use.
- Raise the MSRV from Rust 1.85.0 to 1.86.0, matching the `cargo_metadata` version used by the feature-matrix tooling.

## Validation

- `cargo x check`
- `cargo x test`
- `cargo +1.86.0 x test`
- `cargo x lint`
- `cargo x build --locked`

Closes #102.