### PR TITLE
docs: reorganize project background

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,0 +1,16 @@
+# History
+
+Asyncband collects runtime-agnostic synchronization primitives informed by several existing implementations. Only components that draw on external designs or code are listed here.
+
+- `barrier::Barrier` is inspired by [`std::sync::Barrier`](https://doc.rust-lang.org/std/sync/struct.Barrier.html) and [`tokio::sync::Barrier`](https://docs.rs/tokio/latest/tokio/sync/struct.Barrier.html), with a different implementation based on the internal `WaitSet` primitive.
+- The single-future polling loop in `blocking` is adapted from [`pollster`](https://github.com/zesterer/pollster), its parker caching strategy follows [`futures-lite`](https://github.com/smol-rs/futures-lite), and its private parker state machine is adapted from [`parking`](https://github.com/smol-rs/parking) 2.2.1.
+- `broadcast::overflow::channel` is derived from [`tokio::sync::broadcast::channel`](https://docs.rs/tokio/latest/tokio/sync/broadcast/fn.channel.html), with a different implementation based on the internal `WaitSet` primitive.
+- `condvar::Condvar` is inspired by [`std::sync::Condvar`](https://doc.rust-lang.org/std/sync/struct.Condvar.html) and [`async_std::sync::Condvar`](https://docs.rs/async-std/latest/async_std/sync/struct.Condvar.html), with a fair FIFO waiter queue and standard non-buffered notification semantics.
+- `latch::Latch` is inspired by [`latches`](https://github.com/mirromutth/latches), with a different implementation based on the internal `CountdownState` primitive.
+- `mutex::Mutex` is derived from [`tokio::sync::Mutex`](https://docs.rs/tokio/latest/tokio/sync/struct.Mutex.html).
+- `once::OnceCell` is derived from [`tokio::sync::OnceCell`](https://docs.rs/tokio/latest/tokio/sync/struct.OnceCell.html), but uses Asyncband's semaphore implementation.
+- `once::OnceMap` is inspired by [`uv-once-map`](https://github.com/astral-sh/uv/tree/main/crates/uv-once-map), with a redesigned interface and implementation.
+- `oneshot::channel` is derived from the [`oneshot`](https://github.com/faern/oneshot) crate, with significant simplifications because Asyncband does not provide synchronized receive operations.
+- `rwlock::RwLock` is derived from [`tokio::sync::RwLock`](https://docs.rs/tokio/latest/tokio/sync/struct.RwLock.html), but accepts any `NonZeroUsize` as `max_readers` instead of Tokio's restricted range.
+- `semaphore::Semaphore` is derived from [`tokio::sync::Semaphore`](https://docs.rs/tokio/latest/tokio/sync/struct.Semaphore.html), but omits `close`, avoids Tokio's fixed maximum-permit constant, and adds operations such as `forget_exact` for Asyncband's use cases.
+- `waitgroup::WaitGroup` is inspired by [`waitgroup-rs`](https://github.com/laizy/waitgroup-rs), with a different API and an implementation based on the internal `CountdownState` primitive.

--- a/MIGRATE.md
+++ b/MIGRATE.md
@@ -1,0 +1,9 @@
+# Migrating from MEA
+
+Asyncband continues the codebase formerly published as [`mea`](https://crates.io/crates/mea), but it uses a new Cargo package and Rust crate name. Existing `mea` releases remain available for builds that have not migrated, but they receive no further development.
+
+To migrate, remove the `mea` dependency, add [`asyncband`](https://crates.io/crates/asyncband), and update Rust paths from `mea::` to `asyncband::`. Asyncband enables no primitive modules by default, so list every primitive your application uses in the dependency's Cargo features.
+
+No compatibility package or re-export is provided under the old name, so downstream crates must migrate their dependency declarations and source paths individually.
+
+For the background to the rename, see the [Asyncband proposal discussion](https://lists.apache.org/thread/f31qd3jm3odomjwy3lqkk21coyqsr9xs).

--- a/MIGRATE.md
+++ b/MIGRATE.md
@@ -2,8 +2,22 @@
 
 Asyncband continues the codebase formerly published as [`mea`](https://crates.io/crates/mea), but it uses a new Cargo package and Rust crate name. Existing `mea` releases remain available for builds that have not migrated, but they receive no further development.
 
-To migrate, remove the `mea` dependency, add [`asyncband`](https://crates.io/crates/asyncband), and update Rust paths from `mea::` to `asyncband::`. Asyncband enables no primitive modules by default, so list every primitive your application uses in the dependency's Cargo features.
+## Recommended migration path
 
-No compatibility package or re-export is provided under the old name, so downstream crates must migrate their dependency declarations and source paths individually.
+First, upgrade the existing dependency to `mea` 0.6.7 and resolve any changes required by earlier MEA releases. The [historical changelog](CHANGELOG-OLD.md) documents those releases.
+
+Next, switch from `mea` 0.6.7 to `asyncband` 0.6.7 without changing the dependency's feature configuration, and replace Rust paths from `mea::` to `asyncband::`:
+
+```toml
+# Before
+mea = "0.6.7"
+
+# After
+asyncband = "0.6.7"
+```
+
+Asyncband 0.6.7 is the compatibility point for the rename, so the dependency name and Rust paths are the only changes expected in this step. No compatibility package or re-export keeps the `mea` crate name available; downstream crates must update those names directly.
+
+Once the project builds with Asyncband 0.6.7, upgrade through later Asyncband releases separately. Follow the [Asyncband changelog](CHANGELOG.md) and apply the migration notes for each release instead of combining later breaking changes with the rename.
 
 For the background to the rename, see the [Asyncband proposal discussion](https://lists.apache.org/thread/f31qd3jm3odomjwy3lqkk21coyqsr9xs).

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ assert_eq!(value, Some(42));
 
 ### Async first, blocking by adaptation
 
-Async and synchronous synchronization primitives have different optimization constraints. Once an async primitive is runtime-agnostic, synchronous code can usually drive its future with a `block_on` adapter; [`pollster`](https://github.com/zesterer/pollster) demonstrates how little machinery this requires. Asyncband's `blocking` feature follows the same lightweight model with a thread-parking single-future executor: pending work parks the calling thread and its waker resumes it, providing practical blocking interoperability without busy-waiting or a full async runtime.
+Async and synchronous synchronization primitives have different optimization constraints. Once an async primitive is runtime-agnostic, synchronous code can usually drive its future with a `block_on` adapter. Asyncband's `blocking` feature provides this adapter with a lightweight, thread-parking single-future executor: pending work parks the calling thread and its waker resumes it, providing practical blocking interoperability without busy-waiting or a full async runtime.
 
 A sync-first implementation can still exploit OS- or platform-specific facilities for better performance. Asyncband therefore optimizes its primitives for async code and keeps blocking as a boundary adapter instead of duplicating sync and async methods across every type. This keeps the public API focused while leaving sync-oriented optimizations to dedicated libraries.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # Apache Asyncband (Incubating)
 
 > [!IMPORTANT]
-> **Asyncband was formerly published as MEA.** The [`mea`](https://crates.io/crates/mea) crate is deprecated and receives no further development. New development and releases use the `asyncband` crate; no compatibility crate or re-export is provided under the old name. See [Migrating from MEA](#migrating-from-mea) and the [Asyncband proposal discussion](https://lists.apache.org/thread/f31qd3jm3odomjwy3lqkk21coyqsr9xs) for details.
+>
+> Apache Asyncband (incubating) is an effort undergoing incubation at the Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+>
+> Please read the [DISCLAIMER](DISCLAIMER) and a full explanation of ["incubating"](https://incubator.apache.org/policy/incubation.html).
+>
+> **Asyncband was formerly published as MEA.** The `mea` crate is deprecated and receives no further development. See the [migration guide](MIGRATE.md) for migration instructions and details about the rename.
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
@@ -81,13 +86,15 @@ assert_eq!(value, Some(42));
 
 `asyncband::blocking::FutureExt::block_on(future)` is the equivalent UFCS spelling when function syntax is preferred; it calls the same trait method rather than a separate free function.
 
+### Async first, blocking by adaptation
+
+Async and synchronous synchronization primitives have different optimization constraints. Once an async primitive is runtime-agnostic, synchronous code can usually drive its future with a `block_on` adapter; [`pollster`](https://github.com/zesterer/pollster) demonstrates how little machinery this requires. Asyncband's `blocking` feature follows the same lightweight model with a thread-parking single-future executor: pending work parks the calling thread and its waker resumes it, providing practical blocking interoperability without busy-waiting or a full async runtime.
+
+A sync-first implementation can still exploit OS- or platform-specific facilities for better performance. Asyncband therefore optimizes its primitives for async code and keeps blocking as a boundary adapter instead of duplicating sync and async methods across every type. This keeps the public API focused while leaving sync-oriented optimizations to dedicated libraries.
+
+### Execution constraints
+
 This is a minimal single-future executor, not a general-purpose async runtime. A timed-out `wait_timeout` drops the future. The implementation uses a private parker, so it does not consume wake-ups belonging to other parking operations on the same thread; recursive calls use a separate parker. Futures depending on a runtime-specific timer or I/O driver may not make progress, and blocking an executor thread can cause starvation or deadlocks. See [`asyncband::blocking`](https://docs.rs/asyncband/*/asyncband/blocking/index.html) for details.
-
-## Migrating from MEA
-
-Asyncband continues the codebase formerly published as `mea`, but it uses a new Cargo package and Rust crate name. Remove the `mea` dependency, add `asyncband`, and update `mea::` paths to `asyncband::`. Existing `mea` releases remain available for builds that have not migrated, but they receive no further development.
-
-No compatibility package or re-export is provided, so downstream crates must migrate their dependency declarations individually.
 
 ## Runtime Agnostic
 
@@ -109,23 +116,4 @@ This project is licensed under [Apache License, Version 2.0](LICENSE).
 
 ## History
 
-This crate collects runtime-agnostic synchronization primitives from spare parts:
-
-* **admission::FairShare** is written from scratch to bound global concurrency while balancing held permits across contending keys.
-* **Barrier** is inspired by `std::sync::Barrier` and `tokio::sync::Barrier`, with a different implementation based on the internal `WaitSet` primitive.
-* **Condvar** is inspired by `std::sync::Condvar` and `async_std::sync::Condvar`, with a fair FIFO waiter queue and standard non-buffered notification semantics.
-* **Latch** is inspired by [`latches`](https://github.com/mirromutth/latches), with a different implementation based on the internal `CountdownState` primitive. No sync variant is provided, since it can be easily implemented with block_on of any runtime.
-* **Mutex** is derived from `tokio::sync::Mutex`. No blocking method is provided, since it can be easily implemented with block_on of any runtime.
-* **OnceCell** is derived from `tokio::sync::OnceCell`, but using our own semaphore implementation.
-* **OnceMap** is inspired by `uv-once-map` but the interface and implementation are redesigned.
-* **RwLock** is derived from `tokio::sync::RwLock`, but the `max_readers` can be any `NonZeroUsize` (effectively any positive `usize`) instead of `[0, u32::MAX >> 3]`. No blocking method is provided, since it can be easily implemented with block_on of any runtime.
-* **Semaphore** is derived from `tokio::sync::Semaphore`, without `close` method since it is quite tricky to use. And thus, this semaphore doesn't have the limitation of max permits. Besides, new methods like `forget_exact` are added to fit the specific use case.
-* **WaitGroup** is inspired by [`waitgroup-rs`](https://github.com/laizy/waitgroup-rs), providing different API flavor with a different implementation based on the internal `CountdownState` primitive.
-* The internal atomic pointer slot used by MPSC is derived from [`atomicbox`](https://github.com/jorendorff/atomicbox/) at commit 07756444.
-* The single-future polling loop in `blocking` is adapted from [`pollster`](https://github.com/zesterer/pollster), its parker caching strategy follows [`futures-lite`](https://github.com/smol-rs/futures-lite), and its private parker state machine is adapted from [`parking`](https://github.com/smol-rs/parking) 2.2.1.
-* **broadcast::overflow::channel** is derived from `tokio::sync::broadcast::channel`, with a different implementation based on the internal `WaitSet` primitive.
-* **oneshot::channel** is derived from [`oneshot`](https://github.com/faern/oneshot), with significant simplifications since we need not support synchronized receiving functions.
-
-Other parts are written from scratch.
-
-NB. The optimization considerations are different when implementing a sync primitive for sync code and async code. Generally speaking, once you have an async + runtime-agnostic implementation, you can immediately have a sync implementation by block_on any async runtime ([`pollster`](https://github.com/zesterer/pollster) is the most lightweight runtime that park the current thread). However, a sync-oriented implementation may leverage some platform-specific features to achieve better performance. This library is designed for async code, so it doesn't consider sync-oriented optimization. I often find libraries that try to provide both sync and async implementations end up with a clumsy API design. So I prefer to keep them separate.
+See [HISTORY.md](HISTORY.md) for the external implementations that informed Asyncband's primitives.


### PR DESCRIPTION
## Summary

- align the README incubation notice with the Apache Incubator wording and keep the MEA migration entry there
- move migration guidance and external implementation origins into `MIGRATE.md` and `HISTORY.md`
- document the async-first design and the parker-backed blocking adapter in the synchronous interoperability section

## Validation

- `RUSTUP_TOOLCHAIN=nightly cargo x lint`
- verified new internal references and external links