### PR TITLE
chore: configure ASF repository settings

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,67 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# See https://github.com/apache/infrastructure-asfyaml/ for the configuration reference.
+
+github:
+  description: >-
+    This crate provides concurrency control and async coordination primitives that are runtime agnostic.
+  homepage: https://docs.rs/asyncband/
+  labels:
+    - asynchronous
+    - futures
+    - rust
+    - semaphore
+    - waitgroup
+  enabled_merge_buttons:
+    squash: true
+    squash_commit_message: PR_TITLE_AND_COMMIT_DETAILS
+    merge: false
+    rebase: false
+  features:
+    wiki: false
+    issues: true
+    projects: false
+    discussions: true
+  pull_requests:
+    allow_auto_merge: true
+    allow_update_branch: true
+    del_branch_on_merge: true
+  rulesets:
+    - name: ci
+      type: branch
+      branches:
+        includes:
+          - "~DEFAULT_BRANCH"
+        excludes: []
+      restrict_deletion: true
+      restrict_force_push: true
+      required_pull_request_reviews:
+        dismiss_stale_reviews: false
+        require_last_push_approval: false
+        require_code_owner_reviews: false
+        required_approving_review_count: 0
+      required_status_checks:
+        - name: Required
+          app_slug: github-actions
+      required_status_checks_strict: false
+
+notifications:
+  commits: commits@asyncband.apache.org
+  issues: commits@asyncband.apache.org
+  pullrequests: commits@asyncband.apache.org
+  discussions: dev@asyncband.apache.org


### PR DESCRIPTION
## Summary

- add ASF-managed repository metadata, features, merge buttons, and pull request settings matching the current GitHub configuration
- preserve the existing `ci` ruleset and its required GitHub Actions `Required` check
- route commit, issue, and pull request notifications to `commits@asyncband.apache.org`, and discussions to `dev@asyncband.apache.org`

## Validation

- `uvx --from git+https://github.com/apache/infrastructure-asfyaml.git asfyaml-validate --repo .`
- `git diff --check`