### PR TITLE
chore: establish incubator release process

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -41,6 +41,24 @@ github:
     allow_auto_merge: true
     allow_update_branch: true
     del_branch_on_merge: true
+  environments:
+    release:
+      required_reviewers:
+        - id: jbonofre
+          type: User
+        - id: Xuanwo
+          type: User
+        - id: tisonkun
+          type: User
+        - id: PragmaTwice
+          type: User
+      wait_timer: 0
+      prevent_self_review: true
+      deployment_branch_policy:
+        protected_branches: false
+        policies:
+          - name: "v*.*.*"
+            type: tag
   rulesets:
     - name: ci
       type: branch
@@ -59,6 +77,14 @@ github:
         - name: Required
           app_slug: github-actions
       required_status_checks_strict: false
+    - name: release-tags
+      type: tag
+      branches:
+        includes:
+          - "v*.*.*"
+        excludes: []
+      restrict_deletion: true
+      restrict_force_push: true
 
 notifications:
   commits: commits@asyncband.apache.org

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -53,7 +53,7 @@ github:
         - id: PragmaTwice
           type: User
       wait_timer: 0
-      prevent_self_review: true
+      prevent_self_review: false
       deployment_branch_policy:
         protected_branches: false
         policies:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,116 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Release
+
+on:
+  push:
+    tags: [ "v*.*.*" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_INCREMENTAL: "0"
+  CARGO_TERM_COLOR: always
+  RUSTUP_TOOLCHAIN: stable
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Check package
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    outputs:
+      version: ${{ steps.package.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Install stable toolchain
+        run: >-
+          rustup toolchain install stable
+          --profile minimal
+          --no-self-update
+      - id: package
+        name: Read package version
+        shell: bash
+        run: |
+          version="$(cargo metadata --no-deps --format-version 1 | jq --raw-output '.packages[] | select(.name == "asyncband") | .version')"
+          if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "The asyncband package version must be a stable X.Y.Z version, got: ${version}" >&2
+            exit 1
+          fi
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+      - name: Check tag
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        shell: bash
+        env:
+          PACKAGE_VERSION: ${{ steps.package.outputs.version }}
+        run: |
+          case "${GITHUB_REF_NAME}" in
+            "v${PACKAGE_VERSION}")
+              ;;
+            "v${PACKAGE_VERSION}-rc."*)
+              rc="${GITHUB_REF_NAME#v${PACKAGE_VERSION}-rc.}"
+              if [[ ! "${rc}" =~ ^[1-9][0-9]*$ ]]; then
+                echo "Invalid release candidate tag: ${GITHUB_REF_NAME}" >&2
+                exit 1
+              fi
+              ;;
+            *)
+              echo "Tag ${GITHUB_REF_NAME} does not match package version ${PACKAGE_VERSION}." >&2
+              exit 1
+              ;;
+          esac
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          tag_commit="$(git rev-parse "${GITHUB_REF_NAME}^{commit}")"
+          if ! git merge-base --is-ancestor "${tag_commit}" origin/main; then
+            echo "Release tag ${GITHUB_REF_NAME} does not point to a commit on main." >&2
+            exit 1
+          fi
+      - name: Check crates.io package
+        run: cargo publish --package asyncband --locked --dry-run
+
+  publish:
+    name: Publish to crates.io
+    if: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name == format('v{0}', needs.check.outputs.version) }}
+    needs: check
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install stable toolchain
+        run: >-
+          rustup toolchain install stable
+          --profile minimal
+          --no-self-update
+      - id: auth
+        name: Authenticate with crates.io
+        uses: rust-lang/crates-io-auth-action@v1
+      - name: Publish asyncband
+        run: cargo publish --package asyncband --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,10 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-homepage = "https://github.com/fast/asyncband"
+homepage = "https://github.com/apache/asyncband"
 license = "Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/fast/asyncband"
+repository = "https://github.com/apache/asyncband"
 rust-version = "1.86.0"
 
 [workspace.lints.rust]
@@ -32,10 +32,3 @@ unknown_lints = "deny"
 
 [workspace.lints.clippy]
 dbg_macro = "deny"
-
-[workspace.metadata.release]
-pre-release-commit-message = "chore: release v{{version}}"
-pre-release-hook = ["cargo", "x", "semver", "--release-version", "{{version}}"]
-shared-version = true
-sign-tag = true
-tag-name = "v{{version}}"

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@
 [msrv-badge]: https://img.shields.io/badge/MSRV-1.86-green?logo=rust
 [license-badge]: https://img.shields.io/crates/l/asyncband
 [license-url]: LICENSE
-[actions-badge]: https://github.com/fast/asyncband/actions/workflows/ci.yml/badge.svg
-[actions-url]: https://github.com/fast/asyncband/actions/workflows/ci.yml
+[actions-badge]: https://github.com/apache/asyncband/actions/workflows/ci.yml/badge.svg
+[actions-url]: https://github.com/apache/asyncband/actions/workflows/ci.yml
 
 ## Overview
 
@@ -109,6 +109,10 @@ Asyncband primitives and guards implement `Send` and `Sync` only when the protec
 This crate is built against the latest stable release, and its minimum supported rustc version is 1.86.0.
 
 The policy is that the minimum Rust version required to use this crate can be increased in minor version updates. For example, if Asyncband 1.0 requires Rust 1.20.0, then Asyncband 1.0.z for all values of z will also require Rust 1.20.0 or newer. However, Asyncband 1.y for y > 0 may require a newer minimum version of Rust.
+
+## Releasing
+
+Release managers should follow the [Apache Incubator release guide](https://github.com/apache/asyncband/blob/main/RELEASE.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -110,10 +110,6 @@ This crate is built against the latest stable release, and its minimum supported
 
 The policy is that the minimum Rust version required to use this crate can be increased in minor version updates. For example, if Asyncband 1.0 requires Rust 1.20.0, then Asyncband 1.0.z for all values of z will also require Rust 1.20.0 or newer. However, Asyncband 1.y for y > 0 may require a newer minimum version of Rust.
 
-## Releasing
-
-Release managers should follow the [Apache Incubator release guide](https://github.com/apache/asyncband/blob/main/RELEASE.md).
-
 ## License
 
 This project is licensed under [Apache License, Version 2.0](LICENSE).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -52,7 +52,7 @@ The `asyncband` crate already exists, so a crate owner can configure [crates.io 
 | Workflow filename | `release.yml` |
 | Environment | `release` |
 
-The workflow obtains a short-lived OIDC token and keeps no long-lived crates.io token in GitHub. The `release` GitHub environment is managed by `.asf.yaml`: it accepts version tags, requires approval from another project committer, and prevents self-review.
+The workflow obtains a short-lived OIDC token and keeps no long-lived crates.io token in GitHub. The `release` GitHub environment is managed by `.asf.yaml`: it accepts version tags and requires approval from one of the configured project committers. The person who pushed the tag may approve the deployment.
 
 After one successful Trusted Publishing release, remove any legacy `CARGO_REGISTRY_TOKEN` repository or environment secret and enable **Require trusted publishing for all new versions** in the crate settings. Keep at least two active crate owners so that the publisher configuration can be recovered without depending on one person.
 
@@ -183,7 +183,7 @@ git tag --sign "v${VERSION}" \
 git push https://github.com/apache/asyncband.git "v${VERSION}"
 ```
 
-The final tag starts the crates.io publishing job. A project committer other than the person who pushed the tag must compare the final tag with the approved RC, confirm that the Incubator vote passed, and approve the `release` environment deployment. The workflow verifies that the tag exactly matches the package version and publishes with a short-lived crates.io token.
+The final tag starts the crates.io publishing job. Before approving the `release` environment deployment, a configured project committer must compare the final tag with the approved RC and confirm that the Incubator vote passed. The person who pushed the tag may perform this approval. The workflow verifies that the tag exactly matches the package version and publishes with a short-lived crates.io token.
 
 After publication:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,205 @@
+# Releasing Apache Asyncband (Incubating)
+
+This document is a runbook for release managers. Publishing software has legal consequences, so follow the current [ASF Release Policy](https://www.apache.org/legal/release-policy.html), [ASF Release Distribution Policy](https://infra.apache.org/release-distribution), and [Incubator release guidance](https://incubator.apache.org/guides/releasemanagement.html) if they differ from this document.
+
+> [!IMPORTANT]
+>
+> The signed source archive approved by the Apache Incubator PMC is the official Apache release. The crates.io package is a convenience distribution built from the same approved commit; it must not be published before the Incubator vote passes.
+
+The process deliberately separates release candidates from publication. A signed `vX.Y.Z-rc.N` tag identifies the exact source candidate and only performs a crates.io dry run. After both votes pass, a signed `vX.Y.Z` tag is added to the same commit and triggers the protected crates.io publishing job.
+
+## Terminology
+
+- `VERSION` is the proposed final version, for example `0.7.0`.
+- `RC` is the positive release candidate number, for example `1`.
+- `CANDIDATE` is `${VERSION}-rc.${RC}`, for example `0.7.0-rc.1`.
+- `RC_TAG` is `v${CANDIDATE}` and `FINAL_TAG` is `v${VERSION}`.
+- The official source archive is `apache-asyncband-${VERSION}-incubating-src.tar.gz`. The RC number belongs to the staging directory and tag, not the artifact filename.
+
+## One-time setup
+
+### GPG and ASF distribution directories
+
+The release manager needs an ASF-associated GPG key whose public key is available from the project `KEYS` file. Follow the [ASF release signing guide](https://infra.apache.org/release-signing.html), publish the public key, and verify its fingerprint through an independent channel.
+
+Before the first release, create the project directories if they do not exist:
+
+```shell
+svn mkdir --parents https://dist.apache.org/repos/dist/dev/incubator/asyncband \
+  -m "Initialize Apache Asyncband development distribution area"
+svn mkdir --parents https://dist.apache.org/repos/dist/release/incubator/asyncband \
+  -m "Initialize Apache Asyncband release distribution area"
+```
+
+Export all current release-manager public keys into `KEYS`, review the file, and commit it to the release distribution directory. Append new keys instead of replacing existing valid keys.
+
+```shell
+gpg --armor --export "${ASF_GPG_FINGERPRINT}" > KEYS
+svn import KEYS https://dist.apache.org/repos/dist/release/incubator/asyncband/KEYS \
+  -m "Add Apache Asyncband release keys"
+```
+
+The public verification URL is <https://downloads.apache.org/incubator/asyncband/KEYS>. Update `KEYS` before staging a candidate whenever the signing keys change.
+
+### crates.io Trusted Publishing
+
+The `asyncband` crate already exists, so a crate owner can configure [crates.io Trusted Publishing](https://crates.io/docs/trusted-publishing) without a bootstrap publication. In the crate's **Settings → Trusted Publishing** page, add a GitHub Actions publisher with these exact values:
+
+| Setting | Value |
+| --- | --- |
+| Repository owner | `apache` |
+| Repository name | `asyncband` |
+| Workflow filename | `release.yml` |
+| Environment | `release` |
+
+The workflow obtains a short-lived OIDC token and keeps no long-lived crates.io token in GitHub. The `release` GitHub environment is managed by `.asf.yaml`: it accepts version tags, requires approval from another project committer, and prevents self-review.
+
+After one successful Trusted Publishing release, remove any legacy `CARGO_REGISTRY_TOKEN` repository or environment secret and enable **Require trusted publishing for all new versions** in the crate settings. Keep at least two active crate owners so that the publisher configuration can be recovered without depending on one person.
+
+## 1. Prepare the release pull request
+
+Start from current `main` and choose `VERSION` according to the changes since the latest crates.io release.
+
+1. Change `version` in `asyncband/Cargo.toml` and refresh `Cargo.lock` with Cargo.
+2. Move the entries under `Unreleased` in `CHANGELOG.md` into a dated `VERSION` section, then restore an empty `Unreleased` section.
+3. Confirm that `LICENSE`, `NOTICE`, and `DISCLAIMER` are correct and that all source files have the required license headers.
+4. Run the normal validation and the semver check:
+
+```shell
+cargo x lint
+cargo x check
+cargo x test --no-capture
+cargo x semver --release-version "${VERSION}"
+cargo publish --package asyncband --locked --dry-run
+```
+
+Open and merge a normal pull request. Do not push the version change directly to `main`; the final release is identified by tags, so the release process does not require a direct branch push.
+
+Record the merge commit as `RELEASE_COMMIT`. All candidate artifacts, the final tag, and the crates.io package must come from this exact commit.
+
+## 2. Create and validate a release candidate
+
+Fetch the merged commit, verify it, and create a signed annotated RC tag:
+
+```shell
+git fetch https://github.com/apache/asyncband.git main
+git switch --detach "${RELEASE_COMMIT}"
+git status --short
+git tag --sign "v${VERSION}-rc.${RC}" \
+  --message "Apache Asyncband ${VERSION} release candidate ${RC}" \
+  "${RELEASE_COMMIT}"
+git push https://github.com/apache/asyncband.git "v${VERSION}-rc.${RC}"
+```
+
+Wait for the `Release` GitHub Actions workflow to pass. An RC tag runs package validation but cannot enter the crates.io publishing job. If validation requires a code change, abandon this candidate, merge a new release PR, increment `RC`, and use a new tag; never move or reuse an existing tag.
+
+## 3. Build the official source archive
+
+Build the candidate from the RC tag in a clean clone. The `incubating` marker is mandatory in the filename, and `gzip -n` avoids embedding the local build time.
+
+```shell
+RC_TAG="v${VERSION}-rc.${RC}"
+SOURCE_DIR="apache-asyncband-${VERSION}-incubating-src"
+mkdir -p dist
+git verify-tag "${RC_TAG}"
+git archive --format=tar --prefix="${SOURCE_DIR}/" "${RC_TAG}" \
+  | gzip -n -9 > "dist/${SOURCE_DIR}.tar.gz"
+(
+  cd dist
+  shasum -a 512 "${SOURCE_DIR}.tar.gz" > "${SOURCE_DIR}.tar.gz.sha512"
+  gpg --armor --detach-sign --local-user "${ASF_GPG_FINGERPRINT}" \
+    "${SOURCE_DIR}.tar.gz"
+)
+```
+
+Verify the artifacts before uploading them:
+
+```shell
+cd dist
+shasum -a 512 --check "${SOURCE_DIR}.tar.gz.sha512"
+gpg --verify "${SOURCE_DIR}.tar.gz.asc" "${SOURCE_DIR}.tar.gz"
+tar --extract --gzip --file "${SOURCE_DIR}.tar.gz"
+cd "${SOURCE_DIR}"
+cargo test --workspace --all-features --locked
+cargo publish --package asyncband --locked --dry-run
+```
+
+Also inspect the archive for unexpected binary files, verify `LICENSE`, `NOTICE`, and `DISCLAIMER`, and check that its contents correspond to the RC tag.
+
+## 4. Stage the candidate on ASF infrastructure
+
+Check out an empty working copy so old candidates are not copied accidentally, add the three files, and commit them under the candidate directory:
+
+```shell
+svn checkout --depth=empty \
+  https://dist.apache.org/repos/dist/dev/incubator/asyncband asyncband-dist-dev
+mkdir "asyncband-dist-dev/${VERSION}-rc.${RC}"
+cp "dist/${SOURCE_DIR}.tar.gz"* "asyncband-dist-dev/${VERSION}-rc.${RC}/"
+svn add "asyncband-dist-dev/${VERSION}-rc.${RC}"
+svn status asyncband-dist-dev
+svn commit asyncband-dist-dev \
+  -m "Stage Apache Asyncband ${VERSION} release candidate ${RC}"
+```
+
+Confirm that the candidate is visible at `https://dist.apache.org/repos/dist/dev/incubator/asyncband/${VERSION}-rc.${RC}/` and that every link in the vote email works.
+
+## 5. Hold the two-phase vote
+
+Incubating releases require the [two-phase vote described by the Incubator](https://incubator.apache.org/cookbook/).
+
+First, send `[VOTE] Release Apache Asyncband (Incubating) ${VERSION} RC${RC}` to `dev@asyncband.apache.org`. Include:
+
+- the staged source URL;
+- the `KEYS` URL and signing-key fingerprint;
+- the signed RC tag and commit hash;
+- the changelog or comparison with the previous release;
+- commands or a checklist for verifying signatures, checksums, licensing, absence of unexpected binaries, and the build;
+- a statement that the vote remains open for at least 72 hours.
+
+The podling vote passes with at least three `+1` votes from PPMC members, more PPMC `+1` votes than `-1` votes, and at least 72 hours elapsed. Send a result email that identifies voters and links the archived vote thread.
+
+Then send the same proposal to `general@incubator.apache.org`, including the podling vote result and archive link. This vote also remains open for at least 72 hours and requires at least three binding `+1` votes from Incubator PMC members with a majority in favor. Send a result email after it closes.
+
+Do not create the final tag, publish to crates.io, or announce a release until the Incubator vote passes.
+
+## 6. Promote and publish the approved release
+
+Promote the exact voted artifacts from the development distribution area:
+
+```shell
+svn move \
+  "https://dist.apache.org/repos/dist/dev/incubator/asyncband/${VERSION}-rc.${RC}" \
+  "https://dist.apache.org/repos/dist/release/incubator/asyncband/${VERSION}" \
+  -m "Release Apache Asyncband ${VERSION}"
+```
+
+Wait for the files to appear at `https://downloads.apache.org/incubator/asyncband/${VERSION}/`. Then add a signed final tag to the exact RC commit and push only that tag:
+
+```shell
+RC_COMMIT="$(git rev-list --max-count=1 "v${VERSION}-rc.${RC}")"
+git tag --sign "v${VERSION}" \
+  --message "Apache Asyncband ${VERSION}" \
+  "${RC_COMMIT}"
+git push https://github.com/apache/asyncband.git "v${VERSION}"
+```
+
+The final tag starts the crates.io publishing job. A project committer other than the person who pushed the tag must compare the final tag with the approved RC, confirm that the Incubator vote passed, and approve the `release` environment deployment. The workflow verifies that the tag exactly matches the package version and publishes with a short-lived crates.io token.
+
+After publication:
+
+1. Verify the version and metadata on crates.io and docs.rs.
+2. Create a GitHub release from the final tag containing release notes and links to the ASF source archive; do not attach alternate release artifacts.
+3. Announce the release on `dev@asyncband.apache.org` and other appropriate channels, identifying it as Apache Asyncband (Incubating).
+4. Remove superseded releases from `dist/release`; they remain available from the ASF archive.
+
+## Failed candidates and publication failures
+
+If either vote fails or any candidate content changes, remove the staged candidate, increment `RC`, and restart from a new signed RC tag. Never replace an artifact, checksum, signature, or tag under an existing candidate name.
+
+```shell
+svn delete \
+  "https://dist.apache.org/repos/dist/dev/incubator/asyncband/${VERSION}-rc.${RC}" \
+  -m "Remove rejected Apache Asyncband ${VERSION} release candidate ${RC}"
+```
+
+If the final crates.io job fails before publication, fix only the publishing infrastructure and rerun the same workflow. If the version reached crates.io, it is immutable: do not overwrite it or move tags. Yank it only when necessary, discuss the incident on the development list, and prepare a new version through the full ASF vote when source changes are required.

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -26,9 +26,6 @@ readme.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
-[package.metadata.release]
-release = false
-
 [dependencies]
 cargo_metadata = { version = "0.23.1" }
 clap = { version = "4.6.5", features = ["derive"] }


### PR DESCRIPTION
## Summary

- remove the obsolete `cargo-release` metadata while retaining `cargo x semver` as a release gate
- add `RELEASE.md` with the Apache Incubator source-release flow, including signed RCs, ASF staging, the two-phase vote, artifact promotion, and failure handling
- add a tag-driven crates.io Trusted Publishing workflow with no long-lived registry token
- provision a reviewer-gated `release` environment and make version tags immutable through `.asf.yaml`
- update package metadata and CI links from `fast/asyncband` to `apache/asyncband`

## Release design

RC tags such as `v0.7.0-rc.1` validate the crates.io package but never publish it. After both the podling and Incubator PMC votes pass, the release manager promotes the voted ASF source archive and creates `v0.7.0` at the exact same commit. Only that final tag can enter the protected `release` environment and publish to crates.io.

The crates.io package is treated as a convenience distribution of the approved source release. The workflow verifies the stable manifest version, validates the tag, requires the tagged commit to be on `main`, and authenticates with a short-lived OIDC token. A configured project committer must approve the deployment; the tag pusher may self-approve.

## One-time crates.io setup after merge

A current `asyncband` crate owner needs to add this Trusted Publisher under **Settings → Trusted Publishing**:

| Setting | Value |
| --- | --- |
| Repository owner | `apache` |
| Repository name | `asyncband` |
| Workflow filename | `release.yml` |
| Environment | `release` |

After the first successful OIDC publication, remove any legacy `CARGO_REGISTRY_TOKEN` secret and enable **Require trusted publishing for all new versions**.

## Validation

- `cargo x lint`
- `cargo x check`
- `cargo x test --no-capture`
- `cargo publish --package asyncband --locked --dry-run`
- `actionlint` on both workflows
- official `asfyaml-validate` on `.asf.yaml`
- generated the documented source archive twice and confirmed byte-for-byte reproducibility
- verified the SHA-512 checksum, extracted the archive, and completed `cargo publish --dry-run` from the extracted source
