### PR TITLE
chore: migrate HawkEye to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
         with:
-          tool: typos-cli,taplo-cli,hawkeye@7.0.0-alpha.1
+          tool: typos-cli,taplo-cli,hawkeye
       - run: cargo x lint
       - name: Check feature matrix
         run: cargo x check

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -396,7 +396,7 @@ fn make_semver_check_cmd(
 }
 
 fn make_hawkeye_cmd(fix: bool) -> StdCommand {
-    ensure_installed("hawkeye", "hawkeye@7.0.0-alpha.1");
+    ensure_installed("hawkeye", "hawkeye");
     let mut cmd = find_command("hawkeye");
     if fix {
         cmd.args(["format"]);


### PR DESCRIPTION
## Summary

- migrate the HawkEye configuration and integration to v7
- install HawkEye from its latest release without pinning the tool version
- validate the migrated configuration with HawkEye v7 (102 files, 0 changes, 0 conflicts, 0 unsupported)
- `cargo x lint` passes