### PR TITLE
refactor(semaphore): replace forget APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,12 @@ All notable changes to this project will be documented in this file.
 * Remove `admission::FairShare` and its `admission` Cargo feature from the feature set.
 * Remove the `asyncband::atomicbox` module and its `AtomicBox` and `AtomicOptionBox` types from the public API.
 * Rename `oneshot::Sender::is_closed` and `oneshot::Receiver::is_closed` to `is_disconnected`.
+* Replace `Semaphore::forget` with `Semaphore::drain_permits` and `Semaphore::forget_exact` with `Semaphore::reduce_permits`; permit-level `forget` methods are unchanged.
 * Raise the minimum supported Rust version from 1.85.0 to 1.86.0.
 
 ### Bug fixes
 
-* Release cancelled wait registrations promptly and reclaim fulfilled `Semaphore::forget_exact` debt nodes.
+* Release cancelled wait registrations promptly and reclaim fulfilled `Semaphore::reduce_permits` debt nodes.
 * Serialize broadcast publication so receivers cannot observe reserved slots or messages overwritten out of sequence.
 
 ### Improvements

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,5 +14,5 @@ Asyncband collects runtime-agnostic synchronization primitives informed by sever
 - `once::OnceMap` is inspired by [`uv-once-map`](https://github.com/astral-sh/uv/tree/main/crates/uv-once-map), with a redesigned interface and implementation.
 - `oneshot::channel` is derived from the [`oneshot`](https://github.com/faern/oneshot) crate, with significant simplifications because Asyncband does not provide synchronized receive operations.
 - `rwlock::RwLock` is derived from [`tokio::sync::RwLock`](https://docs.rs/tokio/latest/tokio/sync/struct.RwLock.html), but accepts any `NonZeroUsize` as `max_readers` instead of Tokio's restricted range.
-- `semaphore::Semaphore` is derived from [`tokio::sync::Semaphore`](https://docs.rs/tokio/latest/tokio/sync/struct.Semaphore.html), but omits `close`, avoids Tokio's fixed maximum-permit constant, and adds operations such as `forget_exact` for Asyncband's use cases.
+- `semaphore::Semaphore` is derived from [`tokio::sync::Semaphore`](https://docs.rs/tokio/latest/tokio/sync/struct.Semaphore.html), but omits `close`, avoids Tokio's fixed maximum-permit constant, and adds operations such as `reduce_permits` for Asyncband's use cases.
 - `waitgroup::WaitGroup` is inspired by [`waitgroup-rs`](https://github.com/laizy/waitgroup-rs), with a different API and an implementation based on the internal `CountdownState` primitive.

--- a/asyncband/src/internal/semaphore.rs
+++ b/asyncband/src/internal/semaphore.rs
@@ -78,34 +78,33 @@ impl Semaphore {
         }
     }
 
-    /// Decrease the semaphore's permits by a maximum of `n`.
+    /// Drains up to `up_to` permits that are currently available.
     ///
-    /// Return the number of permits that were actually reduced.
-    pub fn forget(&self, n: usize) -> usize {
-        if n == 0 {
+    /// Returns the number of permits that were actually drained.
+    pub fn drain_permits(&self, up_to: usize) -> usize {
+        if up_to == 0 {
             return 0;
         }
 
         let mut current = self.permits.load(Ordering::Acquire);
         loop {
-            let new = current.saturating_sub(n);
+            let new = current.saturating_sub(up_to);
             match self.permits.compare_exchange_weak(
                 current,
                 new,
                 Ordering::AcqRel,
                 Ordering::Acquire,
             ) {
-                Ok(_) => return n.min(current),
+                Ok(_) => return up_to.min(current),
                 Err(actual) => current = actual,
             }
         }
     }
 
-    /// Decrease the semaphore's permits by `n`.
+    /// Reduces the semaphore's logical permit balance by exactly `n`.
     ///
-    /// If the semaphore has not enough permits, enqueue front an empty waiter to consume the
-    /// permits.
-    pub fn forget_exact(&self, n: usize) {
+    /// If fewer than `n` permits are available, a queue-head debt node consumes future releases.
+    pub fn reduce_permits(&self, n: usize) {
         acquired_or_enqueue(self, n, None, None, false);
     }
 

--- a/asyncband/src/semaphore/mod.rs
+++ b/asyncband/src/semaphore/mod.rs
@@ -129,55 +129,56 @@ impl Semaphore {
         self.s.available_permits()
     }
 
-    /// Reduces the semaphore's permits by a maximum of `n`.
+    /// Atomically drains up to `up_to` permits that are currently available.
     ///
-    /// Returns the actual number of permits that were reduced. This may be less
-    /// than `n` if there are insufficient permits available.
-    ///
-    /// This is useful when you want to permanently remove permits from the semaphore.
+    /// Returns the number of permits actually drained, which may be less than `up_to`.
+    /// This operation neither creates nor cancels a deficit against future releases and does not
+    /// affect permits that have already been acquired.
     ///
     /// # Examples
     ///
     /// ```
     /// use asyncband::semaphore::Semaphore;
     ///
-    /// let sem = Semaphore::new(5);
-    /// assert_eq!(sem.forget(3), 3); // Removes 3 permits
-    /// assert_eq!(sem.available_permits(), 2);
+    /// let sem = Semaphore::new(4);
+    /// let held = sem.try_acquire(2).unwrap();
     ///
-    /// // Trying to forget more permits than available
-    /// assert_eq!(sem.forget(3), 2); // Only removes remaining 2 permits
+    /// assert_eq!(sem.drain_permits(1), 1);
+    /// assert_eq!(sem.available_permits(), 1);
+    /// assert_eq!(sem.drain_permits(3), 1);
     /// assert_eq!(sem.available_permits(), 0);
+    ///
+    /// drop(held);
+    /// assert_eq!(sem.available_permits(), 2);
     /// ```
-    pub fn forget(&self, n: usize) -> usize {
-        self.s.forget(n)
+    #[must_use = "`drain_permits` may drain fewer permits than requested"]
+    pub fn drain_permits(&self, up_to: usize) -> usize {
+        self.s.drain_permits(up_to)
     }
 
-    /// Reduces the semaphore's permits by exactly `n`.
+    /// Reduces the semaphore's logical permit balance by exactly `n`.
     ///
-    /// If the semaphore has not enough permits, this would enqueue front an empty waiter to
-    /// consume the permits, which ensures the permits are reduced by exactly `n`.
-    ///
-    /// This is useful when you want to permanently remove permits from the semaphore.
+    /// This method returns immediately. If fewer than `n` permits are currently available, future
+    /// releases repay the resulting deficit before ordinary queued acquisitions may proceed.
+    /// Permits that have already been acquired remain valid and are not revoked.
     ///
     /// # Examples
     ///
     /// ```
     /// use asyncband::semaphore::Semaphore;
     ///
-    /// let sem = Semaphore::new(5);
-    /// sem.forget_exact(3); // Removes 3 permits
-    /// assert_eq!(sem.available_permits(), 2);
-    ///
-    /// // Trying to forget more permits than available
-    /// sem.forget_exact(3); // Only removes remaining 2 permits
+    /// let sem = Semaphore::new(1);
+    /// sem.reduce_permits(3); // Consumes 1 available permit and records a deficit of 2.
     /// assert_eq!(sem.available_permits(), 0);
     ///
-    /// sem.release(5); // Adds 5 permits
-    /// assert_eq!(sem.available_permits(), 4); // Only 4 permits are available
+    /// sem.release(2); // Repays the deficit, so neither permit becomes available.
+    /// assert_eq!(sem.available_permits(), 0);
+    ///
+    /// sem.release(1); // With the deficit repaid, this permit becomes available.
+    /// assert_eq!(sem.available_permits(), 1);
     /// ```
-    pub fn forget_exact(&self, n: usize) {
-        self.s.forget_exact(n);
+    pub fn reduce_permits(&self, n: usize) {
+        self.s.reduce_permits(n);
     }
 
     /// Adds `n` new permits to the semaphore.
@@ -235,8 +236,8 @@ impl Semaphore {
 
     /// Attempts to acquire `n` permits from the semaphore without blocking.
     ///
-    /// This method performs as a combinator of [`Semaphore::try_acquire`] and
-    /// [`Semaphore::forget`].
+    /// This method is equivalent to successfully calling [`Semaphore::try_acquire`] and then
+    /// calling [`SemaphorePermit::forget`] on the returned permit.
     pub fn try_acquire_and_forget(&self, permits: usize) -> bool {
         self.s.try_acquire(permits)
     }
@@ -283,8 +284,8 @@ impl Semaphore {
 
     /// Acquires `n` permits from the semaphore.
     ///
-    /// This method performs as a combinator of [`Semaphore::acquire`] and
-    /// [`Semaphore::forget`].
+    /// This method is equivalent to calling [`Semaphore::acquire`] and then calling
+    /// [`SemaphorePermit::forget`] on the returned permit.
     pub async fn acquire_and_forget(&self, permits: usize) {
         self.s.acquire(permits).await;
     }
@@ -316,7 +317,7 @@ impl Semaphore {
     /// assert!(p3.is_none());
     /// ```
     ///
-    /// [`forget`]: SemaphorePermit::forget
+    /// [`forget`]: OwnedSemaphorePermit::forget
     pub fn try_acquire_owned(self: Arc<Self>, permits: usize) -> Option<OwnedSemaphorePermit> {
         if self.s.try_acquire(permits) {
             Some(OwnedSemaphorePermit { sem: self, permits })
@@ -329,8 +330,8 @@ impl Semaphore {
     ///
     /// The semaphore must be wrapped in an [`Arc`] to call this method.
     ///
-    /// This method performs as a combinator of [`Semaphore::try_acquire_owned`] and
-    /// [`Semaphore::forget`].
+    /// This method is equivalent to successfully calling [`Semaphore::try_acquire_owned`] and
+    /// then calling [`OwnedSemaphorePermit::forget`] on the returned permit.
     pub fn try_acquire_owned_and_forget(self: Arc<Self>, permits: usize) -> bool {
         self.s.try_acquire(permits)
     }
@@ -382,8 +383,8 @@ impl Semaphore {
     ///
     /// The semaphore must be wrapped in an [`Arc`] to call this method.
     ///
-    /// This method performs as a combinator of [`Semaphore::acquire_owned`] and
-    /// [`Semaphore::forget`].
+    /// This method is equivalent to calling [`Semaphore::acquire_owned`] and then calling
+    /// [`OwnedSemaphorePermit::forget`] on the returned permit.
     pub async fn acquire_owned_and_forget(self: Arc<Self>, permits: usize) {
         self.s.acquire(permits).await;
     }

--- a/asyncband/src/semaphore/tests.rs
+++ b/asyncband/src/semaphore/tests.rs
@@ -20,11 +20,11 @@ use super::Semaphore;
 // This test stays next to the implementation because it inspects private state.
 
 #[test]
-fn fulfilled_forget_exact_debt_reclaims_its_waiter_node() {
+fn fulfilled_reduce_permits_debt_reclaims_its_waiter_node() {
     let semaphore = Semaphore::new(0);
 
     for _ in 0..3 {
-        semaphore.forget_exact(1);
+        semaphore.reduce_permits(1);
         assert_eq!(semaphore.s.num_waiter_nodes(), 1);
 
         semaphore.release(1);

--- a/benchmarks/semaphore.rs
+++ b/benchmarks/semaphore.rs
@@ -67,7 +67,7 @@ fn fulfill_debt_repeatedly(bencher: Bencher) {
     bencher.bench_local(|| {
         let semaphore = Semaphore::new(0);
         for _ in 0..CYCLES {
-            semaphore.forget_exact(black_box(1));
+            semaphore.reduce_permits(black_box(1));
             semaphore.release(black_box(1));
         }
         black_box(semaphore.available_permits())

--- a/tests-integration/tests/semaphore_test.rs
+++ b/tests-integration/tests/semaphore_test.rs
@@ -19,6 +19,7 @@ use std::future::Future;
 use std::pin::pin;
 use std::sync::Arc;
 use std::task::Context;
+use std::task::Poll;
 use std::task::Waker;
 use std::vec::Vec;
 
@@ -185,27 +186,25 @@ fn wake_then_drop() {
     assert_eq!(s.available_permits(), 2);
 }
 
-#[tokio::test]
-async fn acquire_then_forget_exact() {
-    let s = Arc::new(Semaphore::new(5));
-    s.forget_exact(3);
-    assert_eq!(s.available_permits(), 2);
+#[test]
+fn reduce_permits_takes_priority_over_pending_acquires() {
+    let s = Semaphore::new(0);
+    let mut acquire = pin!(s.acquire(1));
+    let waker = Waker::noop();
+    let mut context = Context::from_waker(waker);
 
-    let (acquired_tx, mut acquired_rx) = tokio::sync::oneshot::channel();
+    assert!(acquire.as_mut().poll(&mut context).is_pending());
 
-    let s_clone = s.clone();
-    tokio::spawn(async move {
-        let permit = s_clone.acquire(3).await;
-        drop(permit);
-        acquired_tx.send(()).unwrap();
-    });
-    assert!(acquired_rx.try_recv().is_err());
-
-    s.forget_exact(2);
-    s.release(2);
-    assert!(acquired_rx.try_recv().is_err());
+    s.reduce_permits(1);
+    s.release(1);
+    assert!(acquire.as_mut().poll(&mut context).is_pending());
 
     s.release(1);
-    acquired_rx.await.unwrap();
-    assert_eq!(s.available_permits(), 3);
+    let Poll::Ready(permit) = acquire.as_mut().poll(&mut context) else {
+        panic!("acquire should complete after the reduction debt is repaid");
+    };
+    assert_eq!(s.available_permits(), 0);
+
+    drop(permit);
+    assert_eq!(s.available_permits(), 1);
 }


### PR DESCRIPTION
The old names hid the difference between bounded draining and exact logical balance reduction. Distinct names make both contracts explicit.

CLOSES #171