### PR TITLE
refactor(semaphore): remove acquire-and-forget helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 * Gate all exported primitives behind opt-in Cargo features and enable no features by default; downstream dependencies must explicitly enable the APIs they use.
 * Remove `admission::FairShare` and its `admission` Cargo feature from the feature set.
 * Remove the `asyncband::atomicbox` module and its `AtomicBox` and `AtomicOptionBox` types from the public API.
+* Remove `Semaphore::try_acquire_and_forget`, `Semaphore::acquire_and_forget`, `Semaphore::try_acquire_owned_and_forget`, and `Semaphore::acquire_owned_and_forget`; acquire a permit and call its `forget` method instead.
 * Rename `oneshot::Sender::is_closed` and `oneshot::Receiver::is_closed` to `is_disconnected`.
 * Replace `Semaphore::forget` with `Semaphore::drain_permits` and `Semaphore::forget_exact` with `Semaphore::reduce_permits`; permit-level `forget` methods are unchanged.
 * Raise the minimum supported Rust version from 1.85.0 to 1.86.0.

--- a/asyncband/src/semaphore/mod.rs
+++ b/asyncband/src/semaphore/mod.rs
@@ -234,14 +234,6 @@ impl Semaphore {
         }
     }
 
-    /// Attempts to acquire `n` permits from the semaphore without blocking.
-    ///
-    /// This method is equivalent to successfully calling [`Semaphore::try_acquire`] and then
-    /// calling [`SemaphorePermit::forget`] on the returned permit.
-    pub fn try_acquire_and_forget(&self, permits: usize) -> bool {
-        self.s.try_acquire(permits)
-    }
-
     /// Acquires `n` permits from the semaphore.
     ///
     /// If the permits are not immediately available, this method will wait until they become
@@ -282,14 +274,6 @@ impl Semaphore {
         SemaphorePermit { sem: self, permits }
     }
 
-    /// Acquires `n` permits from the semaphore.
-    ///
-    /// This method is equivalent to calling [`Semaphore::acquire`] and then calling
-    /// [`SemaphorePermit::forget`] on the returned permit.
-    pub async fn acquire_and_forget(&self, permits: usize) {
-        self.s.acquire(permits).await;
-    }
-
     /// Attempts to acquire `n` permits from the semaphore without blocking.
     ///
     /// The semaphore must be wrapped in an [`Arc`] to call this method.
@@ -324,16 +308,6 @@ impl Semaphore {
         } else {
             None
         }
-    }
-
-    /// Attempts to acquire `n` permits from the semaphore without blocking.
-    ///
-    /// The semaphore must be wrapped in an [`Arc`] to call this method.
-    ///
-    /// This method is equivalent to successfully calling [`Semaphore::try_acquire_owned`] and
-    /// then calling [`OwnedSemaphorePermit::forget`] on the returned permit.
-    pub fn try_acquire_owned_and_forget(self: Arc<Self>, permits: usize) -> bool {
-        self.s.try_acquire(permits)
     }
 
     /// Acquires `n` permits from the semaphore.
@@ -377,16 +351,6 @@ impl Semaphore {
     pub async fn acquire_owned(self: Arc<Self>, permits: usize) -> OwnedSemaphorePermit {
         self.s.acquire(permits).await;
         OwnedSemaphorePermit { sem: self, permits }
-    }
-
-    /// Acquires `n` permits from the semaphore.
-    ///
-    /// The semaphore must be wrapped in an [`Arc`] to call this method.
-    ///
-    /// This method is equivalent to calling [`Semaphore::acquire_owned`] and then calling
-    /// [`OwnedSemaphorePermit::forget`] on the returned permit.
-    pub async fn acquire_owned_and_forget(self: Arc<Self>, permits: usize) {
-        self.s.acquire(permits).await;
     }
 }
 


### PR DESCRIPTION
## Summary

Remove these redundant convenience methods for 0.7:

- `Semaphore::try_acquire_and_forget`
- `Semaphore::acquire_and_forget`
- `Semaphore::try_acquire_owned_and_forget`
- `Semaphore::acquire_owned_and_forget`

Permit-level `SemaphorePermit::forget` and `OwnedSemaphorePermit::forget` remain unchanged. The changelog documents the migration.

## Rationale

These helpers were introduced in #33 together with the public `Semaphore::release_all` API for an uncoupled acquire/release workflow. #34 removed `release_all` because it was a footgun, leaving four helpers that only compose existing operations.

The same behavior remains explicit through permit guards:

```rust
semaphore.acquire(n).await.forget();

if let Some(permit) = semaphore.try_acquire(n) {
    permit.forget();
}
```

This operation still uses the normal fair acquisition queue and remains cancellable while waiting. It is intentionally distinct from the immediate bounded `drain_permits` and exact `reduce_permits` operations clarified in #174. Expressing it as acquisition followed by permit-level `forget` preserves that distinction without four extra public methods.

## Testing

- `cargo x lint`
- `cargo x check`
- `cargo x test --no-capture`
- `cargo test --workspace --all-features`