### PR TITLE
ci: check GitHub Actions against ASF allowlist

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,31 +15,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: ASF Allowlist Check
-
-on:
-  workflow_dispatch:
-  # Detect allowlist removals and expiry warnings even without workflow changes.
-  schedule:
-    - cron: "17 3 * * 1"
-  pull_request:
-    paths:
-      - ".github/**"
-  push:
-    branches:
-      - main
-    paths:
-      - ".github/**"
-
-permissions:
-  contents: read
-
-jobs:
-  asf-allowlist-check:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: apache/infrastructure-actions/allowlist-check@61dcea11f19e2bbe1263f14d72235e8da17d3ad0 # allowlist-check/v1.0.0
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    # Give ASF Infrastructure time to approve new action releases first.
+    cooldown:
+      default-days: 4
+    commit-message:
+      prefix: ci
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+      github-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"

--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: ASF Allowlist Check
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/**"
+
+permissions:
+  contents: read
+
+jobs:
+  asf-allowlist-check:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: apache/infrastructure-actions/allowlist-check@61dcea11f19e2bbe1263f14d72235e8da17d3ad0 # allowlist-check/v1.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           --component clippy
           --allow-downgrade
           --no-self-update
-      - uses: Swatinem/rust-cache@v2
+      - uses: swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
         with:
           tool: typos-cli,taplo-cli,hawkeye
@@ -82,7 +82,7 @@ jobs:
           rustup toolchain install ${{ matrix.rust-version }}
           --profile minimal
           --no-self-update
-      - uses: Swatinem/rust-cache@v2
+      - uses: swatinem/rust-cache@v2
       - name: Run unit tests
         run: cargo x test --no-capture
         shell: bash
@@ -100,7 +100,7 @@ jobs:
           rustup toolchain install stable
           --profile minimal
           --no-self-update
-      - uses: Swatinem/rust-cache@v2
+      - uses: swatinem/rust-cache@v2
       - run: cargo x bench
 
   required:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     env:
       RUSTUP_TOOLCHAIN: nightly
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install nightly toolchain
         run: >-
           rustup toolchain install nightly
@@ -56,8 +56,8 @@ jobs:
           --component clippy
           --allow-downgrade
           --no-self-update
-      - uses: swatinem/rust-cache@v2
-      - uses: taiki-e/install-action@v2
+      - uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - uses: taiki-e/install-action@6cd13508893c0e7eab5f273c2575d3859bd7229a # v2.86.6
         with:
           tool: typos-cli,taplo-cli,hawkeye
       - run: cargo x lint
@@ -76,13 +76,13 @@ jobs:
     env:
       RUSTUP_TOOLCHAIN: ${{ matrix.rust-version }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Rust ${{ matrix.rust-version }}
         run: >-
           rustup toolchain install ${{ matrix.rust-version }}
           --profile minimal
           --no-self-update
-      - uses: swatinem/rust-cache@v2
+      - uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Run unit tests
         run: cargo x test --no-capture
         shell: bash
@@ -94,13 +94,13 @@ jobs:
     env:
       RUSTUP_TOOLCHAIN: stable
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install stable toolchain
         run: >-
           rustup toolchain install stable
           --profile minimal
           --no-self-update
-      - uses: swatinem/rust-cache@v2
+      - uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - run: cargo x bench
 
   required:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
           --no-self-update
       - id: auth
         name: Authenticate with crates.io
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
       - name: Publish asyncband
         run: cargo publish --package asyncband --locked
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
     outputs:
       version: ${{ steps.package.outputs.version }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Install stable toolchain
@@ -101,7 +101,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install stable toolchain
         run: >-
           rustup toolchain install stable


### PR DESCRIPTION
## Summary

- add the ASF allowlist check for `.github/**` changes, manual runs, and weekly policy-drift checks
- pin every GitHub Action reference to an immutable release commit with a Dependabot-readable version comment
- configure weekly grouped GitHub Actions updates with a four-day cooldown so ASF Infrastructure can approve releases first
- use a `ci:` commit prefix for generated update PRs so they satisfy the repository semantic-title policy

## Testing

- `cargo x lint`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest`
- ASF allowlist checker against the current `approved_patterns.yml` (all 5 unique refs allowed)
- Dependabot configuration validation against the Dependabot 2.0 schema
- canonical-ref check (all 12 `uses:` entries have a 40-character SHA and version comment)