### PR TITLE
chore: update homepage URL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
-homepage = "https://github.com/apache/asyncband"
+homepage = "https://asyncband.apache.org"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/apache/asyncband"


### PR DESCRIPTION
Update the website to https://asyncband.apache.org.