### PR TITLE
perf(semaphore): store wake batch on stack

### DIFF
--- a/asyncband/src/internal/semaphore.rs
+++ b/asyncband/src/internal/semaphore.rs
@@ -254,10 +254,13 @@ impl Drop for Acquire<'_> {
                 node.permits = 0;
                 true
             });
-            waiters.remove_unlinked_waiter(index);
+            let waiter = waiters.remove_unlinked_waiter(index);
             if acquired > 0 {
                 self.semaphore.insert_permits_with_lock(acquired, waiters);
+            } else {
+                drop(waiters);
             }
+            drop(waiter);
         }
     }
 }
@@ -275,6 +278,7 @@ impl Acquire<'_> {
             return Poll::Ready(());
         }
 
+        let mut old_waker = None;
         match index {
             Some(idx) => {
                 let mut waiters = semaphore.waiters.lock();
@@ -286,7 +290,7 @@ impl Acquire<'_> {
                             .as_ref()
                             .is_none_or(|current| !current.will_wake(waker));
                         if update_waker {
-                            node.waker = Some(waker.clone());
+                            old_waker = node.waker.replace(waker.clone());
                         }
                         false
                     } else {
@@ -311,6 +315,7 @@ impl Acquire<'_> {
             }
         };
 
+        drop(old_waker);
         Poll::Pending
     }
 }

--- a/asyncband/src/internal/semaphore.rs
+++ b/asyncband/src/internal/semaphore.rs
@@ -16,7 +16,9 @@
 // under the License.
 
 use std::future::Future;
+use std::mem::MaybeUninit;
 use std::pin::Pin;
+use std::ptr;
 use std::sync::MutexGuard;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
@@ -42,6 +44,59 @@ struct WaitNode {
     /// A linked node without a waker is permit debt owned by the queue. An acquire node only loses
     /// its waker while being detached, after which its future still owns the node.
     waker: Option<Waker>,
+}
+
+const WAKE_BATCH_SIZE: usize = 32;
+
+/// The initialized entries in `wakers` are exactly `start..end`.
+struct WakeBatch {
+    wakers: [MaybeUninit<Waker>; WAKE_BATCH_SIZE],
+    start: usize,
+    end: usize,
+}
+
+impl WakeBatch {
+    fn new() -> Self {
+        const UNINIT: MaybeUninit<Waker> = MaybeUninit::uninit();
+        Self {
+            wakers: [UNINIT; WAKE_BATCH_SIZE],
+            start: 0,
+            end: 0,
+        }
+    }
+
+    fn push(&mut self, waker: Waker) {
+        debug_assert_eq!(self.start, 0);
+        debug_assert!(self.end < WAKE_BATCH_SIZE);
+        self.wakers[self.end].write(waker);
+        self.end += 1;
+    }
+
+    fn is_full(&self) -> bool {
+        self.end == WAKE_BATCH_SIZE
+    }
+
+    fn wake_all(&mut self) {
+        while self.start < self.end {
+            let index = self.start;
+            self.start += 1;
+            // SAFETY: `index` was within the initialized range before advancing `start`.
+            unsafe { self.wakers[index].assume_init_read() }.wake();
+        }
+        self.start = 0;
+        self.end = 0;
+    }
+}
+
+impl Drop for WakeBatch {
+    fn drop(&mut self) {
+        let start = self.wakers[self.start..self.end]
+            .as_mut_ptr()
+            .cast::<Waker>();
+        let remaining = ptr::slice_from_raw_parts_mut(start, self.end - self.start);
+        // SAFETY: The initialized entries are exactly `start..end`.
+        unsafe { ptr::drop_in_place(remaining) };
+    }
 }
 
 impl Semaphore {
@@ -176,13 +231,12 @@ impl Semaphore {
         mut rem: usize,
         waiters: MutexGuard<'_, WaitList<WaitNode>>,
     ) {
-        const NUM_WAKER: usize = 32;
-        let mut wakers = Vec::new();
+        let mut wakers = WakeBatch::new();
 
         let mut lock = Some(waiters);
         while rem > 0 {
             let mut waiters = lock.take().unwrap_or_else(|| self.waiters.lock());
-            while wakers.len() < NUM_WAKER {
+            while !wakers.is_full() {
                 match waiters.unlink_first_waiter(|node| {
                     if node.permits <= rem {
                         rem -= node.permits;
@@ -198,10 +252,6 @@ impl Semaphore {
                     Some((id, waiter)) => {
                         let remove_now = waiter.waker.is_none();
                         if let Some(waker) = waiter.waker.take() {
-                            // Only allocate when we have an actual waker to store.
-                            if wakers.is_empty() {
-                                wakers.reserve(NUM_WAKER);
-                            }
                             wakers.push(waker);
                         }
                         if remove_now {
@@ -224,9 +274,7 @@ impl Semaphore {
             }
 
             drop(waiters);
-            for w in wakers.drain(..) {
-                w.wake();
-            }
+            wakers.wake_all();
         }
     }
 

--- a/tests-integration/tests/semaphore_test.rs
+++ b/tests-integration/tests/semaphore_test.rs
@@ -20,6 +20,7 @@ use std::pin::pin;
 use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
+use std::task::Wake;
 use std::task::Waker;
 use std::vec::Vec;
 
@@ -184,6 +185,41 @@ fn wake_then_drop() {
         }
     }
     assert_eq!(s.available_permits(), 2);
+}
+
+#[test]
+fn cancellation_restores_permits_before_dropping_waker() {
+    struct AssertPermitsOnDrop {
+        semaphore: Arc<Semaphore>,
+    }
+
+    impl Wake for AssertPermitsOnDrop {
+        fn wake(self: Arc<Self>) {
+            panic!("cancellation must not wake the removed waiter");
+        }
+    }
+
+    impl Drop for AssertPermitsOnDrop {
+        fn drop(&mut self) {
+            assert_eq!(self.semaphore.available_permits(), 1);
+        }
+    }
+
+    let semaphore = Arc::new(Semaphore::new(1));
+    let waker = Waker::from(Arc::new(AssertPermitsOnDrop {
+        semaphore: semaphore.clone(),
+    }));
+    let mut acquire = Box::pin(semaphore.acquire(2));
+
+    assert!(
+        acquire
+            .as_mut()
+            .poll(&mut Context::from_waker(&waker))
+            .is_pending()
+    );
+    drop(waker);
+    drop(acquire);
+    assert_eq!(Arc::strong_count(&semaphore), 1);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- replace the lazily allocated `Vec<Waker>` in semaphore release with a fixed 32-slot stack batch
- preserve the existing unlock-before-wake batching and FIFO wake order
- keep panic cleanup explicit: `start..end` is the only initialized range, and advancing `start` before wake lets unwind drop the remaining wakers

This is stacked on #189 so the Waker correctness changes remain independently reviewable.

A shorter `[Option<Waker>; 32]` prototype regressed the empty-queue `release` benchmark by about 18%. The final `MaybeUninit` helper avoids initializing unused slots and keeps a single documented invariant.

## Benchmarks

Apple Silicon, medians, alternating this branch with #189 using 0.5s minimum time and 80 samples:

| Benchmark | #189 | This PR | Change |
| --- | ---: | ---: | ---: |
| `handoff_permit` | 124.4 ns | 82.55 ns | -33.6% |
| `queued_owned_burst/1` | 249.4 ns | 207.5 ns | -16.8% |
| `queued_owned_burst/8` | 665.4 ns | 556.8 ns | -16.3% |
| `queued_owned_burst/32` | 2.290 us | 1.812 us | -20.9% |
| `release` | 22.11 ns | 20.71 ns | -6.3% |

Command:

```console
cargo bench -p benchmarks --bench benchmarks -- semaphore::handoff_permit semaphore::queued_owned_burst semaphore::release --min-time 0.5 --sample-count 80 --color never
```

## Testing

- `cargo +1.86.0 check -p asyncband --all-features`
- `cargo x lint`
- `cargo x test --no-capture`
