### PR TITLE
refactor: clarify waiter arena contracts

### DIFF
--- a/asyncband/src/barrier/mod.rs
+++ b/asyncband/src/barrier/mod.rs
@@ -77,8 +77,8 @@ use std::task::Context;
 use std::task::Poll;
 
 use crate::internal::mutex::Mutex;
-use crate::internal::waitset::WaitRegistration;
 use crate::internal::waitset::WaitSet;
+use crate::internal::waitset::WakerToken;
 
 /// A synchronization primitive for multiple tasks that need to wait for each other.
 ///
@@ -255,7 +255,7 @@ impl Barrier {
         };
 
         let fut = BarrierWait {
-            registration: None,
+            token: None,
             generation,
             barrier: self,
         };
@@ -269,7 +269,7 @@ impl Barrier {
 /// This future will complete when all tasks have reached the barrier point.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 struct BarrierWait<'a> {
-    registration: Option<WaitRegistration>,
+    token: Option<WakerToken>,
     generation: usize,
     barrier: &'a Barrier,
 }
@@ -287,7 +287,7 @@ impl Future for BarrierWait<'_> {
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let Self {
-            registration,
+            token,
             generation,
             barrier,
         } = self.get_mut();
@@ -296,10 +296,10 @@ impl Future for BarrierWait<'_> {
             let mut state = barrier.state.lock();
             if *generation < state.generation {
                 // Advancing the generation drains its registrations under this same lock.
-                *registration = None;
+                *token = None;
                 return Poll::Ready(());
             }
-            state.waiters.register_waker(registration, cx)
+            state.waiters.register_waker(token, cx)
         };
         drop(replaced_waker);
         Poll::Pending
@@ -308,10 +308,10 @@ impl Future for BarrierWait<'_> {
 
 impl Drop for BarrierWait<'_> {
     fn drop(&mut self) {
-        if self.registration.is_some() {
+        if self.token.is_some() {
             let removed_waker = {
                 let mut state = self.barrier.state.lock();
-                state.waiters.unregister_waker(&mut self.registration)
+                state.waiters.unregister_waker(&mut self.token)
             };
             drop(removed_waker);
         }

--- a/asyncband/src/internal/arena.rs
+++ b/asyncband/src/internal/arena.rs
@@ -25,7 +25,7 @@ use std::num::NonZeroUsize;
 /// lifecycle rule that matches its waiter storage.
 #[repr(transparent)]
 #[derive(Clone, Copy, Eq, PartialEq)]
-pub(super) struct ArenaKey(NonZeroUsize);
+pub struct ArenaKey(NonZeroUsize);
 
 impl ArenaKey {
     fn from_index(index: usize) -> Self {
@@ -53,7 +53,7 @@ impl std::fmt::Debug for ArenaKey {
 /// once in the singly linked vacant list, which starts at `next_vacant` and terminates at
 /// `slots.len()`. Removing a value makes its key available for immediate reuse.
 #[derive(Debug)]
-pub(super) struct Arena<T> {
+pub struct Arena<T> {
     slots: Vec<Slot<T>>,
     /// The next reusable slot, or `slots.len()` when every slot is occupied.
     next_vacant: usize,
@@ -87,7 +87,7 @@ enum Slot<T> {
 }
 
 impl<T> Arena<T> {
-    pub(super) const fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             slots: Vec::new(),
             next_vacant: 0,
@@ -95,7 +95,7 @@ impl<T> Arena<T> {
         }
     }
 
-    pub(super) fn with_capacity(capacity: usize) -> Self {
+    pub fn with_capacity(capacity: usize) -> Self {
         Self {
             slots: Vec::with_capacity(capacity),
             next_vacant: 0,
@@ -103,7 +103,7 @@ impl<T> Arena<T> {
         }
     }
 
-    pub(super) fn insert(&mut self, value: T) -> ArenaKey {
+    pub fn insert(&mut self, value: T) -> ArenaKey {
         let key = self.next_vacant;
         self.len += 1;
 
@@ -123,14 +123,14 @@ impl<T> Arena<T> {
         ArenaKey::from_index(key)
     }
 
-    pub(super) fn get(&self, key: ArenaKey) -> Option<&T> {
+    pub fn get(&self, key: ArenaKey) -> Option<&T> {
         match self.slots.get(key.index()) {
             Some(Slot::Occupied(value)) => Some(value),
             Some(Slot::Vacant { .. }) | None => None,
         }
     }
 
-    pub(super) fn get_mut(&mut self, key: ArenaKey) -> Option<&mut T> {
+    pub fn get_mut(&mut self, key: ArenaKey) -> Option<&mut T> {
         match self.slots.get_mut(key.index()) {
             Some(Slot::Occupied(value)) => Some(value),
             Some(Slot::Vacant { .. }) | None => None,
@@ -144,7 +144,7 @@ impl<T> Arena<T> {
     /// Panics if the key is out of bounds or its slot is already vacant. Either case is an internal
     /// waiter-lifecycle violation rather than a recoverable lookup failure.
     #[track_caller]
-    pub(super) fn remove(&mut self, key: ArenaKey) -> T {
+    pub fn remove(&mut self, key: ArenaKey) -> T {
         let index = key.index();
         let slot = self
             .slots
@@ -172,7 +172,7 @@ impl<T> Arena<T> {
     /// Every previously issued key becomes invalid, including keys for slots that were already
     /// vacant. Consumers that retain keys across this operation must supply their own epoch check.
     #[inline]
-    pub(super) fn take_all(&mut self) -> impl Iterator<Item = T> + use<T> {
+    pub fn take_all(&mut self) -> impl Iterator<Item = T> + use<T> {
         let len = self.len;
         let mut values = ArenaValues {
             first: None,
@@ -197,7 +197,7 @@ impl<T> Arena<T> {
     }
 
     #[cfg(test)]
-    pub(super) fn len(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.len
     }
 }

--- a/asyncband/src/internal/arena.rs
+++ b/asyncband/src/internal/arena.rs
@@ -66,7 +66,7 @@ pub(super) struct Arena<T> {
 /// store additional values in a `Vec`, and support consuming iteration. Keeping that representation
 /// focused avoids a general unsafe collection implementation for a single internal operation.
 #[derive(Debug)]
-pub(super) struct ArenaValues<T> {
+struct ArenaValues<T> {
     first: Option<T>,
     rest: Vec<T>,
 }
@@ -172,7 +172,7 @@ impl<T> Arena<T> {
     /// Every previously issued key becomes invalid, including keys for slots that were already
     /// vacant. Consumers that retain keys across this operation must supply their own epoch check.
     #[inline]
-    pub(super) fn take_all(&mut self) -> ArenaValues<T> {
+    pub(super) fn take_all(&mut self) -> impl Iterator<Item = T> + use<T> {
         let len = self.len;
         let mut values = ArenaValues {
             first: None,
@@ -193,7 +193,7 @@ impl<T> Arena<T> {
 
         self.next_vacant = 0;
         self.len = 0;
-        values
+        values.into_iter()
     }
 
     #[cfg(test)]
@@ -237,7 +237,7 @@ mod tests {
         let capacity = arena.slots.capacity();
         arena.remove(second);
 
-        assert_eq!(arena.take_all().into_iter().collect::<Vec<_>>(), vec![1, 3]);
+        assert_eq!(arena.take_all().collect::<Vec<_>>(), vec![1, 3]);
         assert_eq!(arena.len(), 0);
         assert_eq!(arena.slots.capacity(), capacity);
 

--- a/asyncband/src/internal/arena.rs
+++ b/asyncband/src/internal/arena.rs
@@ -18,26 +18,42 @@
 use std::mem;
 use std::num::NonZeroUsize;
 
-/// A stable index into an [`Arena`] for as long as its slot remains occupied.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct ArenaKey(usize);
+/// A reusable slot index that remains valid only while its slot is occupied.
+///
+/// The non-zero representation lets wrappers such as `WaiterId` retain a niche when stored in an
+/// `Option`. Keys deliberately carry no per-slot generation: each consumer supplies the cheaper
+/// lifecycle rule that matches its waiter storage.
+#[repr(transparent)]
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub(super) struct ArenaKey(NonZeroUsize);
 
 impl ArenaKey {
-    /// Encodes this key so it can provide a niche when stored in an `Option`-wrapped structure.
-    pub fn encode(self) -> NonZeroUsize {
+    fn from_index(index: usize) -> Self {
         // `Slot<T>` is non-zero-sized, so a Vec of slots cannot reach `usize::MAX` elements.
-        unsafe { NonZeroUsize::new_unchecked(self.0 + 1) }
+        let encoded = index
+            .checked_add(1)
+            .expect("arena index must fit in a non-zero usize");
+        Self(NonZeroUsize::new(encoded).expect("encoded arena index must be non-zero"))
     }
 
-    /// Decodes a key produced by [`Self::encode`].
-    pub fn decode(encoded: NonZeroUsize) -> Self {
-        Self(encoded.get() - 1)
+    fn index(self) -> usize {
+        self.0.get() - 1
+    }
+}
+
+impl std::fmt::Debug for ArenaKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("ArenaKey").field(&self.index()).finish()
     }
 }
 
 /// Minimal reusable storage for internal waiter state.
+///
+/// The occupied length equals the number of `Occupied` slots. Every `Vacant` slot appears exactly
+/// once in the singly linked vacant list, which starts at `next_vacant` and terminates at
+/// `slots.len()`. Removing a value makes its key available for immediate reuse.
 #[derive(Debug)]
-pub struct Arena<T> {
+pub(super) struct Arena<T> {
     slots: Vec<Slot<T>>,
     /// The next reusable slot, or `slots.len()` when every slot is occupied.
     next_vacant: usize,
@@ -45,8 +61,12 @@ pub struct Arena<T> {
 }
 
 /// Values extracted from an [`Arena`], storing the common single-value case inline.
+///
+/// This is the specialized subset of a small-vector abstraction needed here: keep one value inline,
+/// store additional values in a `Vec`, and support consuming iteration. Keeping that representation
+/// focused avoids a general unsafe collection implementation for a single internal operation.
 #[derive(Debug)]
-pub struct ArenaValues<T> {
+pub(super) struct ArenaValues<T> {
     first: Option<T>,
     rest: Vec<T>,
 }
@@ -63,11 +83,11 @@ impl<T> IntoIterator for ArenaValues<T> {
 #[derive(Debug)]
 enum Slot<T> {
     Occupied(T),
-    Vacant(usize),
+    Vacant { next: usize },
 }
 
 impl<T> Arena<T> {
-    pub const fn new() -> Self {
+    pub(super) const fn new() -> Self {
         Self {
             slots: Vec::new(),
             next_vacant: 0,
@@ -75,7 +95,7 @@ impl<T> Arena<T> {
         }
     }
 
-    pub fn with_capacity(capacity: usize) -> Self {
+    pub(super) fn with_capacity(capacity: usize) -> Self {
         Self {
             slots: Vec::with_capacity(capacity),
             next_vacant: 0,
@@ -83,7 +103,7 @@ impl<T> Arena<T> {
         }
     }
 
-    pub fn insert(&mut self, value: T) -> ArenaKey {
+    pub(super) fn insert(&mut self, value: T) -> ArenaKey {
         let key = self.next_vacant;
         self.len += 1;
 
@@ -92,7 +112,7 @@ impl<T> Arena<T> {
             self.next_vacant = key + 1;
         } else {
             self.next_vacant = match self.slots.get(key) {
-                Some(Slot::Vacant(next)) => *next,
+                Some(Slot::Vacant { next }) => *next,
                 Some(Slot::Occupied(_)) | None => {
                     unreachable!("arena free list must point to a vacant slot")
                 }
@@ -100,32 +120,44 @@ impl<T> Arena<T> {
             self.slots[key] = Slot::Occupied(value);
         }
 
-        ArenaKey(key)
+        ArenaKey::from_index(key)
     }
 
-    pub fn get(&self, key: ArenaKey) -> Option<&T> {
-        match self.slots.get(key.0) {
+    pub(super) fn get(&self, key: ArenaKey) -> Option<&T> {
+        match self.slots.get(key.index()) {
             Some(Slot::Occupied(value)) => Some(value),
-            Some(Slot::Vacant(_)) | None => None,
+            Some(Slot::Vacant { .. }) | None => None,
         }
     }
 
-    pub fn get_mut(&mut self, key: ArenaKey) -> Option<&mut T> {
-        match self.slots.get_mut(key.0) {
+    pub(super) fn get_mut(&mut self, key: ArenaKey) -> Option<&mut T> {
+        match self.slots.get_mut(key.index()) {
             Some(Slot::Occupied(value)) => Some(value),
-            Some(Slot::Vacant(_)) | None => None,
+            Some(Slot::Vacant { .. }) | None => None,
         }
     }
 
-    pub fn remove(&mut self, key: ArenaKey) -> T {
-        let index = key.0;
+    /// Removes the value stored at `key`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the key is out of bounds or its slot is already vacant. Either case is an internal
+    /// waiter-lifecycle violation rather than a recoverable lookup failure.
+    #[track_caller]
+    pub(super) fn remove(&mut self, key: ArenaKey) -> T {
+        let index = key.index();
         let slot = self
             .slots
             .get_mut(index)
             .expect("arena key must be in bounds");
-        let value = match mem::replace(slot, Slot::Vacant(self.next_vacant)) {
+        let value = match mem::replace(
+            slot,
+            Slot::Vacant {
+                next: self.next_vacant,
+            },
+        ) {
             Slot::Occupied(value) => value,
-            vacant @ Slot::Vacant(_) => {
+            vacant @ Slot::Vacant { .. } => {
                 *slot = vacant;
                 panic!("arena key must be occupied");
             }
@@ -135,9 +167,12 @@ impl<T> Arena<T> {
         value
     }
 
-    /// Takes every occupied value while retaining the allocation for reuse.
+    /// Takes every occupied value in slot order while retaining the allocation for reuse.
+    ///
+    /// Every previously issued key becomes invalid, including keys for slots that were already
+    /// vacant. Consumers that retain keys across this operation must supply their own epoch check.
     #[inline]
-    pub fn take_all(&mut self) -> ArenaValues<T> {
+    pub(super) fn take_all(&mut self) -> ArenaValues<T> {
         let len = self.len;
         let mut values = ArenaValues {
             first: None,
@@ -162,7 +197,7 @@ impl<T> Arena<T> {
     }
 
     #[cfg(test)]
-    pub fn len(&self) -> usize {
+    pub(super) fn len(&self) -> usize {
         self.len
     }
 }
@@ -170,6 +205,14 @@ impl<T> Arena<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn key_preserves_the_option_niche() {
+        assert_eq!(
+            std::mem::size_of::<ArenaKey>(),
+            std::mem::size_of::<Option<ArenaKey>>()
+        );
+    }
 
     #[test]
     fn removed_slots_are_reused() {

--- a/asyncband/src/internal/arena.rs
+++ b/asyncband/src/internal/arena.rs
@@ -18,16 +18,15 @@
 use std::mem;
 use std::num::NonZeroUsize;
 
-/// A reusable slot index that remains valid only while its slot is occupied.
+/// Identifies a reusable slot while that slot is occupied.
 ///
 /// The non-zero representation lets wrappers such as `WaiterId` retain a niche when stored in an
-/// `Option`. Keys deliberately carry no per-slot generation: each consumer supplies the cheaper
+/// `Option`. Slot IDs deliberately carry no generation: each consumer supplies the cheaper
 /// lifecycle rule that matches its waiter storage.
-#[repr(transparent)]
 #[derive(Clone, Copy, Eq, PartialEq)]
-pub struct ArenaKey(NonZeroUsize);
+pub struct SlotId(NonZeroUsize);
 
-impl ArenaKey {
+impl SlotId {
     fn from_index(index: usize) -> Self {
         // `Slot<T>` is non-zero-sized, so a Vec of slots cannot reach `usize::MAX` elements.
         let encoded = index
@@ -41,9 +40,9 @@ impl ArenaKey {
     }
 }
 
-impl std::fmt::Debug for ArenaKey {
+impl std::fmt::Debug for SlotId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("ArenaKey").field(&self.index()).finish()
+        f.debug_tuple("SlotId").field(&self.index()).finish()
     }
 }
 
@@ -51,7 +50,7 @@ impl std::fmt::Debug for ArenaKey {
 ///
 /// The occupied length equals the number of `Occupied` slots. Every `Vacant` slot appears exactly
 /// once in the singly linked vacant list, which starts at `next_vacant` and terminates at
-/// `slots.len()`. Removing a value makes its key available for immediate reuse.
+/// `slots.len()`. Removing a value makes its slot ID available for immediate reuse.
 #[derive(Debug)]
 pub struct Arena<T> {
     slots: Vec<Slot<T>>,
@@ -103,53 +102,53 @@ impl<T> Arena<T> {
         }
     }
 
-    pub fn insert(&mut self, value: T) -> ArenaKey {
-        let key = self.next_vacant;
+    pub fn insert(&mut self, value: T) -> SlotId {
+        let index = self.next_vacant;
         self.len += 1;
 
-        if key == self.slots.len() {
+        if index == self.slots.len() {
             self.slots.push(Slot::Occupied(value));
-            self.next_vacant = key + 1;
+            self.next_vacant = index + 1;
         } else {
-            self.next_vacant = match self.slots.get(key) {
+            self.next_vacant = match self.slots.get(index) {
                 Some(Slot::Vacant { next }) => *next,
                 Some(Slot::Occupied(_)) | None => {
                     unreachable!("arena free list must point to a vacant slot")
                 }
             };
-            self.slots[key] = Slot::Occupied(value);
+            self.slots[index] = Slot::Occupied(value);
         }
 
-        ArenaKey::from_index(key)
+        SlotId::from_index(index)
     }
 
-    pub fn get(&self, key: ArenaKey) -> Option<&T> {
-        match self.slots.get(key.index()) {
+    pub fn get(&self, id: SlotId) -> Option<&T> {
+        match self.slots.get(id.index()) {
             Some(Slot::Occupied(value)) => Some(value),
             Some(Slot::Vacant { .. }) | None => None,
         }
     }
 
-    pub fn get_mut(&mut self, key: ArenaKey) -> Option<&mut T> {
-        match self.slots.get_mut(key.index()) {
+    pub fn get_mut(&mut self, id: SlotId) -> Option<&mut T> {
+        match self.slots.get_mut(id.index()) {
             Some(Slot::Occupied(value)) => Some(value),
             Some(Slot::Vacant { .. }) | None => None,
         }
     }
 
-    /// Removes the value stored at `key`.
+    /// Removes the value stored at `id`.
     ///
     /// # Panics
     ///
-    /// Panics if the key is out of bounds or its slot is already vacant. Either case is an internal
-    /// waiter-lifecycle violation rather than a recoverable lookup failure.
+    /// Panics if the slot ID is out of bounds or its slot is already vacant. Either case is an
+    /// internal waiter-lifecycle violation rather than a recoverable lookup failure.
     #[track_caller]
-    pub fn remove(&mut self, key: ArenaKey) -> T {
-        let index = key.index();
+    pub fn remove(&mut self, id: SlotId) -> T {
+        let index = id.index();
         let slot = self
             .slots
             .get_mut(index)
-            .expect("arena key must be in bounds");
+            .expect("arena slot ID must be in bounds");
         let value = match mem::replace(
             slot,
             Slot::Vacant {
@@ -159,7 +158,7 @@ impl<T> Arena<T> {
             Slot::Occupied(value) => value,
             vacant @ Slot::Vacant { .. } => {
                 *slot = vacant;
-                panic!("arena key must be occupied");
+                panic!("arena slot ID must be occupied");
             }
         };
         self.len -= 1;
@@ -169,8 +168,8 @@ impl<T> Arena<T> {
 
     /// Takes every occupied value in slot order while retaining the allocation for reuse.
     ///
-    /// Every previously issued key becomes invalid, including keys for slots that were already
-    /// vacant. Consumers that retain keys across this operation must supply their own epoch check.
+    /// Every previously issued slot ID becomes invalid, including IDs for slots that were already
+    /// vacant. Consumers that retain IDs across this operation must supply their own epoch check.
     #[inline]
     pub fn take_all(&mut self) -> impl Iterator<Item = T> + use<T> {
         let len = self.len;
@@ -207,11 +206,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn key_preserves_the_option_niche() {
-        assert_eq!(
-            std::mem::size_of::<ArenaKey>(),
-            std::mem::size_of::<Option<ArenaKey>>()
-        );
+    fn slot_id_preserves_the_option_niche() {
+        assert_eq!(size_of::<SlotId>(), size_of::<Option<SlotId>>());
     }
 
     #[test]
@@ -229,7 +225,7 @@ mod tests {
     }
 
     #[test]
-    fn take_all_restarts_key_allocation() {
+    fn take_all_restarts_slot_id_allocation() {
         let mut arena = Arena::with_capacity(3);
         let first = arena.insert(1);
         let second = arena.insert(2);
@@ -241,7 +237,7 @@ mod tests {
         assert_eq!(arena.len(), 0);
         assert_eq!(arena.slots.capacity(), capacity);
 
-        let keys = [arena.insert(4), arena.insert(5), arena.insert(6)];
-        assert_eq!(keys, [first, second, third]);
+        let slot_ids = [arena.insert(4), arena.insert(5), arena.insert(6)];
+        assert_eq!(slot_ids, [first, second, third]);
     }
 }

--- a/asyncband/src/internal/countdown.rs
+++ b/asyncband/src/internal/countdown.rs
@@ -21,8 +21,8 @@ use std::task::Context;
 use std::task::Poll;
 
 use crate::internal::mutex::Mutex;
-use crate::internal::waitset::WaitRegistration;
 use crate::internal::waitset::WaitSet;
+use crate::internal::waitset::WakerToken;
 
 #[derive(Debug)]
 pub struct CountdownState {
@@ -72,15 +72,11 @@ impl CountdownState {
     }
 
     /// Polls for zero, registering the current waker if the countdown is still active.
-    pub fn poll_wait(
-        &self,
-        registration: &mut Option<WaitRegistration>,
-        cx: &mut Context<'_>,
-    ) -> Poll<()> {
+    pub fn poll_wait(&self, token: &mut Option<WakerToken>, cx: &mut Context<'_>) -> Poll<()> {
         if self.spin_wait(16).is_ok() {
             // The zero transition owns draining this wake epoch. Avoid taking the waiter lock
             // again when the completed future is dropped.
-            *registration = None;
+            *token = None;
             return Poll::Ready(());
         }
 
@@ -88,21 +84,21 @@ impl CountdownState {
             let mut waiters = self.waiters.lock();
             if self.state() == 0 {
                 // A concurrent zero transition will drain after this lock is released.
-                *registration = None;
+                *token = None;
                 return Poll::Ready(());
             }
-            waiters.register_waker(registration, cx)
+            waiters.register_waker(token, cx)
         };
         drop(replaced_waker);
         Poll::Pending
     }
 
     #[inline]
-    pub fn unregister_waker(&self, registration: &mut Option<WaitRegistration>) {
-        if registration.is_some() {
+    pub fn unregister_waker(&self, token: &mut Option<WakerToken>) {
+        if token.is_some() {
             let removed_waker = {
                 let mut waiters = self.waiters.lock();
-                waiters.unregister_waker(registration)
+                waiters.unregister_waker(token)
             };
             drop(removed_waker);
         }

--- a/asyncband/src/internal/mod.rs
+++ b/asyncband/src/internal/mod.rs
@@ -30,7 +30,7 @@ pub(crate) mod atomic_waker;
 // `WaitList` and `WaitSet` use different `Arena` operations. A single-primitive build therefore
 // leaves part of this shared API unused, while the all-feature build uses it.
 #[allow(dead_code)]
-pub(crate) mod arena;
+mod arena;
 
 #[cfg(any(feature = "latch", feature = "once", feature = "waitgroup"))]
 // `waitgroup` increments and decrements the countdown, while `latch` and `once` only decrement it.

--- a/asyncband/src/internal/mod.rs
+++ b/asyncband/src/internal/mod.rs
@@ -27,21 +27,10 @@ pub(crate) mod atomic_waker;
     feature = "semaphore",
     feature = "waitgroup",
 ))]
-// `WaitList` and `WaitSet` use different `Arena` operations. Only a build with `barrier` (the sole
-// `with_capacity` user) and a queue-backed primitive exercises the complete shared API.
-#[cfg_attr(
-    not(all(
-        feature = "barrier",
-        any(
-            feature = "mpsc",
-            feature = "mutex",
-            feature = "rwlock",
-            feature = "semaphore",
-        )
-    )),
-    allow(dead_code)
-)]
-mod arena;
+// `WaitList` and `WaitSet` use different `Arena` operations. A single-primitive build therefore
+// leaves part of this shared API unused, while the all-feature build uses it.
+#[allow(dead_code)]
+pub(crate) mod arena;
 
 #[cfg(any(feature = "latch", feature = "once", feature = "waitgroup"))]
 // `waitgroup` increments and decrements the countdown, while `latch` and `once` only decrement it.

--- a/asyncband/src/internal/mod.rs
+++ b/asyncband/src/internal/mod.rs
@@ -27,10 +27,21 @@ pub(crate) mod atomic_waker;
     feature = "semaphore",
     feature = "waitgroup",
 ))]
-// `WaitList` and `WaitSet` use different `Arena` operations. A single-primitive build therefore
-// leaves part of this shared API unused, while the all-feature build uses it.
-#[allow(dead_code)]
-pub(crate) mod arena;
+// `WaitList` and `WaitSet` use different `Arena` operations. Only a build with `barrier` (the sole
+// `with_capacity` user) and a queue-backed primitive exercises the complete shared API.
+#[cfg_attr(
+    not(all(
+        feature = "barrier",
+        any(
+            feature = "mpsc",
+            feature = "mutex",
+            feature = "rwlock",
+            feature = "semaphore",
+        )
+    )),
+    allow(dead_code)
+)]
+mod arena;
 
 #[cfg(any(feature = "latch", feature = "once", feature = "waitgroup"))]
 // `waitgroup` increments and decrements the countdown, while `latch` and `once` only decrement it.

--- a/asyncband/src/internal/waitlist.rs
+++ b/asyncband/src/internal/waitlist.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::internal::arena::Arena;
-use crate::internal::arena::ArenaKey;
+use crate::internal::arena::SlotId;
 
 /// A linked waiter queue whose detached nodes remain addressable until removal.
 #[derive(Debug)]
@@ -26,16 +26,15 @@ pub struct WaitList<T> {
     nodes: Arena<Node<T>>,
 }
 
-#[repr(transparent)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct WaiterId(ArenaKey);
+pub struct WaiterId(SlotId);
 
 impl WaiterId {
-    fn new(key: ArenaKey) -> Self {
-        Self(key)
+    fn new(slot: SlotId) -> Self {
+        Self(slot)
     }
 
-    fn key(self) -> ArenaKey {
+    fn slot(self) -> SlotId {
         self.0
     }
 }
@@ -156,18 +155,18 @@ impl<T> WaitList<T> {
             self.node(id).links.is_none(),
             "waiter must be unlinked before removal"
         );
-        self.nodes.remove(id.key()).value
+        self.nodes.remove(id.slot()).value
     }
 
     fn node(&self, id: WaiterId) -> &Node<T> {
         self.nodes
-            .get(id.key())
+            .get(id.slot())
             .expect("waiter id must refer to an occupied node")
     }
 
     fn node_mut(&mut self, id: WaiterId) -> &mut Node<T> {
         self.nodes
-            .get_mut(id.key())
+            .get_mut(id.slot())
             .expect("waiter id must refer to an occupied node")
     }
 
@@ -190,10 +189,7 @@ mod tests {
 
     #[test]
     fn waiter_id_preserves_the_option_niche() {
-        assert_eq!(
-            std::mem::size_of::<WaiterId>(),
-            std::mem::size_of::<Option<WaiterId>>()
-        );
+        assert_eq!(size_of::<WaiterId>(), size_of::<Option<WaiterId>>());
     }
 
     #[test]

--- a/asyncband/src/internal/waitlist.rs
+++ b/asyncband/src/internal/waitlist.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::num::NonZeroUsize;
-
 use crate::internal::arena::Arena;
 use crate::internal::arena::ArenaKey;
 
@@ -28,16 +26,17 @@ pub struct WaitList<T> {
     nodes: Arena<Node<T>>,
 }
 
+#[repr(transparent)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct WaiterId(NonZeroUsize);
+pub struct WaiterId(ArenaKey);
 
 impl WaiterId {
     fn new(key: ArenaKey) -> Self {
-        Self(key.encode())
+        Self(key)
     }
 
     fn key(self) -> ArenaKey {
-        ArenaKey::decode(self.0)
+        self.0
     }
 }
 
@@ -190,6 +189,14 @@ mod tests {
     use super::*;
 
     #[test]
+    fn waiter_id_preserves_the_option_niche() {
+        assert_eq!(
+            std::mem::size_of::<WaiterId>(),
+            std::mem::size_of::<Option<WaiterId>>()
+        );
+    }
+
+    #[test]
     fn detached_nodes_remain_available_until_removed() {
         let mut waiters = WaitList::new();
         let first = waiters.push_back(1);
@@ -199,7 +206,17 @@ mod tests {
         assert_eq!(*waiters.waiter_mut(first), 1);
         assert_eq!(waiters.occupied_len(), 2);
 
-        assert_eq!(waiters.remove_unlinked_waiter(first), 1);
+        assert_eq!(
+            *waiters
+                .unlink_waiter(first, |value| {
+                    *value += 10;
+                    true
+                })
+                .unwrap(),
+            11
+        );
+
+        assert_eq!(waiters.remove_unlinked_waiter(first), 11);
         assert_eq!(waiters.unlink_first_waiter(|_| true).unwrap().0, second);
         assert!(waiters.is_empty());
         assert_eq!(waiters.remove_unlinked_waiter(second), 2);
@@ -214,6 +231,26 @@ mod tests {
         let last = waiters.push_back(3);
 
         for expected in [(first, 1), (middle, 2), (last, 3)] {
+            let (id, value) = waiters.unlink_first_waiter(|_| true).unwrap();
+            assert_eq!((id, *value), expected);
+            waiters.remove_unlinked_waiter(id);
+        }
+        assert!(waiters.is_empty());
+    }
+
+    #[test]
+    fn unlinking_a_middle_waiter_preserves_the_queue() {
+        let mut waiters = WaitList::new();
+        let first = waiters.push_back(1);
+        let middle = waiters.push_back(2);
+        let last = waiters.push_back(3);
+
+        assert!(waiters.unlink_waiter(middle, |_| false).is_none());
+        assert_eq!(*waiters.unlink_waiter(middle, |_| true).unwrap(), 2);
+        assert_eq!(waiters.remove_unlinked_waiter(middle), 2);
+
+        let replacement = waiters.push_back(4);
+        for expected in [(first, 1), (last, 3), (replacement, 4)] {
             let (id, value) = waiters.unlink_first_waiter(|_| true).unwrap();
             assert_eq!((id, *value), expected);
             waiters.remove_unlinked_waiter(id);

--- a/asyncband/src/internal/waitset.rs
+++ b/asyncband/src/internal/waitset.rs
@@ -20,16 +20,16 @@ use std::task::Context;
 use std::task::Waker;
 
 use crate::internal::arena::Arena;
-use crate::internal::arena::ArenaKey;
+use crate::internal::arena::SlotId;
 
-/// A single-owner handle to a registered waiter.
+/// A single-owner token for a waker registered in a [`WaitSet`].
 ///
-/// This deliberately does not implement `Clone` or `Copy`: duplicating a registration could let
-/// a stale handle refer to a slot reused by another waiter in the same epoch.
+/// This deliberately does not implement `Clone` or `Copy`: duplicating a token could let a stale
+/// token refer to a slot reused by another waiter in the same epoch.
 #[derive(Debug)]
-pub struct WaitRegistration {
+pub struct WakerToken {
     epoch: u64,
-    key: ArenaKey,
+    slot: SlotId,
 }
 
 #[derive(Debug)]
@@ -69,15 +69,15 @@ impl WaitSet {
     #[inline]
     pub fn register_waker(
         &mut self,
-        registration: &mut Option<WaitRegistration>,
+        token: &mut Option<WakerToken>,
         cx: &mut Context<'_>,
     ) -> Option<Waker> {
-        if let Some(current) = registration.as_ref() {
+        if let Some(current) = token.as_ref() {
             if current.epoch == self.epoch {
                 let waker = self
                     .waiters
-                    .get_mut(current.key)
-                    .expect("current wait registration must be occupied");
+                    .get_mut(current.slot)
+                    .expect("current waker token must refer to an occupied slot");
                 if !waker.will_wake(cx.waker()) {
                     return Some(mem::replace(waker, cx.waker().clone()));
                 }
@@ -85,24 +85,21 @@ impl WaitSet {
             }
         }
 
-        *registration = Some(WaitRegistration {
+        *token = Some(WakerToken {
             epoch: self.epoch,
-            key: self.waiters.insert(cx.waker().clone()),
+            slot: self.waiters.insert(cx.waker().clone()),
         });
         None
     }
 
-    /// Removes a registration if it still belongs to the current wake epoch.
+    /// Removes the waker identified by `token` if it still belongs to the current wake epoch.
     ///
     /// The returned waker must be dropped after releasing the lock that protects this wait set.
     #[inline]
-    pub fn unregister_waker(
-        &mut self,
-        registration: &mut Option<WaitRegistration>,
-    ) -> Option<Waker> {
-        let registration = registration.take()?;
-        if registration.epoch == self.epoch {
-            return Some(self.waiters.remove(registration.key));
+    pub fn unregister_waker(&mut self, token: &mut Option<WakerToken>) -> Option<Waker> {
+        let token = token.take()?;
+        if token.epoch == self.epoch {
+            return Some(self.waiters.remove(token.slot));
         }
         None
     }
@@ -124,10 +121,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn registration_preserves_the_option_niche() {
+    fn waker_token_preserves_the_option_niche() {
         assert_eq!(
-            std::mem::size_of::<WaitRegistration>(),
-            std::mem::size_of::<Option<WaitRegistration>>()
+            std::mem::size_of::<WakerToken>(),
+            std::mem::size_of::<Option<WakerToken>>()
         );
     }
 
@@ -167,14 +164,14 @@ mod tests {
 
     fn register(
         waiters: &mut WaitSet,
-        registration: &mut Option<WaitRegistration>,
+        token: &mut Option<WakerToken>,
         waker: &Waker,
     ) -> Option<Waker> {
-        waiters.register_waker(registration, &mut Context::from_waker(waker))
+        waiters.register_waker(token, &mut Context::from_waker(waker))
     }
 
     #[test]
-    fn stale_registration_does_not_alias_a_reused_slot() {
+    fn stale_token_does_not_alias_a_reused_slot() {
         let mut waiters = WaitSet::new();
         let first_waker = Waker::from(Arc::new(TrackWake(AtomicUsize::new(0))));
         let second_waker = Waker::from(Arc::new(TrackWake(AtomicUsize::new(0))));
@@ -201,12 +198,12 @@ mod tests {
     fn unregister_returns_the_waker_for_deferred_drop() {
         let mut waiters = WaitSet::new();
         let (waker, dropped) = drop_waker();
-        let mut registration = None;
+        let mut token = None;
 
-        register(&mut waiters, &mut registration, &waker);
+        register(&mut waiters, &mut token, &waker);
         drop(waker);
 
-        let removed = waiters.unregister_waker(&mut registration);
+        let removed = waiters.unregister_waker(&mut token);
         assert_eq!(waiters.registered_len(), 0);
         assert!(!dropped.load(Ordering::Relaxed));
 
@@ -219,12 +216,12 @@ mod tests {
         let mut waiters = WaitSet::new();
         let (old_waker, dropped) = drop_waker();
         let new_waker = Waker::from(Arc::new(TrackWake(AtomicUsize::new(0))));
-        let mut registration = None;
+        let mut token = None;
 
-        assert!(register(&mut waiters, &mut registration, &old_waker).is_none());
+        assert!(register(&mut waiters, &mut token, &old_waker).is_none());
         drop(old_waker);
 
-        let replaced = register(&mut waiters, &mut registration, &new_waker);
+        let replaced = register(&mut waiters, &mut token, &new_waker);
         assert!(!dropped.load(Ordering::Relaxed));
 
         drop(replaced);

--- a/asyncband/src/internal/waitset.rs
+++ b/asyncband/src/internal/waitset.rs
@@ -16,13 +16,11 @@
 // under the License.
 
 use std::mem;
-use std::num::NonZeroUsize;
 use std::task::Context;
 use std::task::Waker;
 
 use crate::internal::arena::Arena;
 use crate::internal::arena::ArenaKey;
-use crate::internal::arena::ArenaValues;
 
 /// A single-owner handle to a registered waiter.
 ///
@@ -31,7 +29,7 @@ use crate::internal::arena::ArenaValues;
 #[derive(Debug)]
 pub struct WaitRegistration {
     epoch: u64,
-    key: NonZeroUsize,
+    key: ArenaKey,
 }
 
 #[derive(Debug)]
@@ -57,11 +55,11 @@ impl WaitSet {
         }
     }
 
-    /// Takes all registered wakers without waking them.
+    /// Takes all registered wakers as an owning iterator without waking them.
     #[inline]
-    pub fn take_wakers(&mut self) -> ArenaValues<Waker> {
+    pub fn take_wakers(&mut self) -> impl Iterator<Item = Waker> + 'static {
         self.epoch = self.epoch.checked_add(1).expect("wait set epoch overflow");
-        self.waiters.take_all()
+        self.waiters.take_all().into_iter()
     }
 
     /// Registers or updates a waker in the current wake epoch.
@@ -78,7 +76,7 @@ impl WaitSet {
             if current.epoch == self.epoch {
                 let waker = self
                     .waiters
-                    .get_mut(ArenaKey::decode(current.key))
+                    .get_mut(current.key)
                     .expect("current wait registration must be occupied");
                 if !waker.will_wake(cx.waker()) {
                     return Some(mem::replace(waker, cx.waker().clone()));
@@ -89,7 +87,7 @@ impl WaitSet {
 
         *registration = Some(WaitRegistration {
             epoch: self.epoch,
-            key: self.waiters.insert(cx.waker().clone()).encode(),
+            key: self.waiters.insert(cx.waker().clone()),
         });
         None
     }
@@ -104,7 +102,7 @@ impl WaitSet {
     ) -> Option<Waker> {
         let registration = registration.take()?;
         if registration.epoch == self.epoch {
-            return Some(self.waiters.remove(ArenaKey::decode(registration.key)));
+            return Some(self.waiters.remove(registration.key));
         }
         None
     }
@@ -124,6 +122,14 @@ mod tests {
     use std::task::Wake;
 
     use super::*;
+
+    #[test]
+    fn registration_preserves_the_option_niche() {
+        assert_eq!(
+            std::mem::size_of::<WaitRegistration>(),
+            std::mem::size_of::<Option<WaitRegistration>>()
+        );
+    }
 
     struct TrackWake(AtomicUsize);
 
@@ -176,12 +182,12 @@ mod tests {
         let mut second = None;
 
         register(&mut waiters, &mut first, &first_waker);
-        assert_eq!(waiters.take_wakers().into_iter().count(), 1);
+        assert_eq!(waiters.take_wakers().count(), 1);
 
         register(&mut waiters, &mut second, &second_waker);
         register(&mut waiters, &mut first, &first_waker);
 
-        let registered = waiters.take_wakers().into_iter().collect::<Vec<_>>();
+        let registered = waiters.take_wakers().collect::<Vec<_>>();
         assert_eq!(registered.len(), 2);
         assert!(registered.iter().any(|waker| waker.will_wake(&first_waker)));
         assert!(

--- a/asyncband/src/internal/waitset.rs
+++ b/asyncband/src/internal/waitset.rs
@@ -59,7 +59,7 @@ impl WaitSet {
     #[inline]
     pub fn take_wakers(&mut self) -> impl Iterator<Item = Waker> + 'static {
         self.epoch = self.epoch.checked_add(1).expect("wait set epoch overflow");
-        self.waiters.take_all().into_iter()
+        self.waiters.take_all()
     }
 
     /// Registers or updates a waker in the current wake epoch.

--- a/asyncband/src/latch/mod.rs
+++ b/asyncband/src/latch/mod.rs
@@ -63,7 +63,7 @@ use std::task::Context;
 use std::task::Poll;
 
 use crate::internal::countdown::CountdownState;
-use crate::internal::waitset::WaitRegistration;
+use crate::internal::waitset::WakerToken;
 
 /// A synchronization primitive that can be used to coordinate multiple tasks.
 ///
@@ -209,7 +209,7 @@ impl Latch {
     /// ```
     pub async fn wait(&self) {
         let fut = LatchWait {
-            registration: None,
+            token: None,
             latch: self,
         };
         fut.await
@@ -245,7 +245,7 @@ impl Latch {
     /// ```
     pub async fn wait_owned(self: Arc<Self>) {
         let fut = OwnedLatchWait {
-            registration: None,
+            token: None,
             latch: self,
         };
         fut.await
@@ -253,12 +253,8 @@ impl Latch {
 }
 
 impl Latch {
-    fn intern_poll(
-        &self,
-        registration: &mut Option<WaitRegistration>,
-        cx: &mut Context<'_>,
-    ) -> Poll<()> {
-        self.state.poll_wait(registration, cx)
+    fn intern_poll(&self, token: &mut Option<WakerToken>, cx: &mut Context<'_>) -> Poll<()> {
+        self.state.poll_wait(token, cx)
     }
 }
 
@@ -267,7 +263,7 @@ impl Latch {
 /// This future will complete when the latch count reaches zero.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct LatchWait<'a> {
-    registration: Option<WaitRegistration>,
+    token: Option<WakerToken>,
     latch: &'a Latch,
 }
 
@@ -281,18 +277,15 @@ impl Future for LatchWait<'_> {
     type Output = ();
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let Self {
-            registration,
-            latch,
-        } = self.get_mut();
-        latch.intern_poll(registration, cx)
+        let Self { token, latch } = self.get_mut();
+        latch.intern_poll(token, cx)
     }
 }
 
 impl Drop for LatchWait<'_> {
     fn drop(&mut self) {
-        if self.registration.is_some() {
-            self.latch.state.unregister_waker(&mut self.registration);
+        if self.token.is_some() {
+            self.latch.state.unregister_waker(&mut self.token);
         }
     }
 }
@@ -302,7 +295,7 @@ impl Drop for LatchWait<'_> {
 /// This future will complete when the latch count reaches zero.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct OwnedLatchWait {
-    registration: Option<WaitRegistration>,
+    token: Option<WakerToken>,
     latch: Arc<Latch>,
 }
 
@@ -316,18 +309,15 @@ impl Future for OwnedLatchWait {
     type Output = ();
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let Self {
-            registration,
-            latch,
-        } = self.get_mut();
-        latch.intern_poll(registration, cx)
+        let Self { token, latch } = self.get_mut();
+        latch.intern_poll(token, cx)
     }
 }
 
 impl Drop for OwnedLatchWait {
     fn drop(&mut self) {
-        if self.registration.is_some() {
-            self.latch.state.unregister_waker(&mut self.registration);
+        if self.token.is_some() {
+            self.latch.state.unregister_waker(&mut self.token);
         }
     }
 }

--- a/asyncband/src/once/once/mod.rs
+++ b/asyncband/src/once/once/mod.rs
@@ -21,7 +21,7 @@ use std::task::Context;
 use std::task::Poll;
 
 use crate::internal::countdown::CountdownState;
-use crate::internal::waitset::WaitRegistration;
+use crate::internal::waitset::WakerToken;
 use crate::semaphore::Semaphore;
 
 /// A synchronization primitive which can be used to run a one-time async initialization.
@@ -209,7 +209,7 @@ impl Once {
         }
 
         OnceWait {
-            registration: None,
+            token: None,
             once: self,
         }
         .await
@@ -217,7 +217,7 @@ impl Once {
 }
 
 struct OnceWait<'a> {
-    registration: Option<WaitRegistration>,
+    token: Option<WakerToken>,
     once: &'a Once,
 }
 
@@ -231,15 +231,15 @@ impl Future for OnceWait<'_> {
     type Output = ();
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let Self { registration, once } = self.get_mut();
-        once.done.poll_wait(registration, cx)
+        let Self { token, once } = self.get_mut();
+        once.done.poll_wait(token, cx)
     }
 }
 
 impl Drop for OnceWait<'_> {
     fn drop(&mut self) {
-        if self.registration.is_some() {
-            self.once.done.unregister_waker(&mut self.registration);
+        if self.token.is_some() {
+            self.once.done.unregister_waker(&mut self.token);
         }
     }
 }

--- a/asyncband/src/waitgroup/mod.rs
+++ b/asyncband/src/waitgroup/mod.rs
@@ -62,7 +62,7 @@ use std::task::Context;
 use std::task::Poll;
 
 use crate::internal::countdown::CountdownState;
-use crate::internal::waitset::WaitRegistration;
+use crate::internal::waitset::WakerToken;
 
 #[cfg(test)]
 mod tests;
@@ -138,10 +138,7 @@ impl IntoFuture for WaitGroup {
     fn into_future(self) -> Self::IntoFuture {
         let state = self.state.clone();
         drop(self);
-        Wait {
-            registration: None,
-            state,
-        }
+        Wait { token: None, state }
     }
 }
 
@@ -152,7 +149,7 @@ impl IntoFuture for WaitGroup {
 /// will complete when the WaitGroup counter reaches zero.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Wait {
-    registration: Option<WaitRegistration>,
+    token: Option<WakerToken>,
     state: Arc<CountdownState>,
 }
 
@@ -162,7 +159,7 @@ impl Clone for Wait {
     /// This does not increment the WaitGroup counter.
     fn clone(&self) -> Self {
         Wait {
-            registration: None,
+            token: None,
             state: self.state.clone(),
         }
     }
@@ -178,18 +175,15 @@ impl Future for Wait {
     type Output = ();
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let Self {
-            registration,
-            state,
-        } = self.get_mut();
-        state.poll_wait(registration, cx)
+        let Self { token, state } = self.get_mut();
+        state.poll_wait(token, cx)
     }
 }
 
 impl Drop for Wait {
     fn drop(&mut self) {
-        if self.registration.is_some() {
-            self.state.unregister_waker(&mut self.registration);
+        if self.token.is_some() {
+            self.state.unregister_waker(&mut self.token);
         }
     }
 }


### PR DESCRIPTION
## Summary

- represent reusable arena slots with `SlotId`, removing manual encode/decode calls and the associated unsafe construction
- represent a caller-owned `WaitSet` entry with the non-`Copy` `WakerToken`, and use `slot`/`token` consistently through its callers
- document the arena free-list, slot-ID lifetime, and wake-epoch invariants while preserving `next_vacant` as the field name
- make the arena module and inline-one value holder private, with the sibling-facing arena API declared `pub` inside that module boundary
- hide `ArenaValues` behind owning iterators from `Arena::take_all` and `WaitSet::take_wakers`
- retain option-niche size checks without imposing unnecessary `repr(transparent)` layout guarantees on internal wrappers
- cover repeated unlinking of detached waiters, middle-waiter removal with slot reuse, and stale Waker tokens across wake epochs

The existing module-level `allow(dead_code)` remains intentionally simple: `WaitList` and `WaitSet` use different subsets of the arena API, so single-primitive feature builds inevitably leave part of it unused.

## Small-vector decision

`ArenaValues` is the safe, specialized equivalent of the small-vector behavior needed here: keep one value inline, store only additional values in a `Vec`, and consume the values through iteration. I evaluated vendoring SmallVec 1.15.2, but its general implementation and unsafe storage machinery are disproportionate to these three operations. This keeps the focused representation without adding a production dependency or vendored third-party surface.

## Validation

- `cargo +1.86.0 check --package asyncband --all-features --tests`
- `cargo test --workspace --all-features`
- `cargo run -p x -- check`
- `cargo run -p x -- lint`
