### PR TITLE
chore: allow module inception workspace-wide

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,4 @@ unknown_lints = "deny"
 
 [workspace.lints.clippy]
 dbg_macro = "deny"
+module_inception = "allow"

--- a/asyncband/src/once/mod.rs
+++ b/asyncband/src/once/mod.rs
@@ -18,7 +18,6 @@
 //! Asynchronous primitives for one-time coordination.
 
 #[cfg(feature = "once")]
-#[allow(clippy::module_inception)]
 mod once;
 #[cfg(feature = "once-cell")]
 mod once_cell;


### PR DESCRIPTION
## Summary

- allow Clippy's `module_inception` lint at the workspace level
- remove the item-level allowance from the `once` module

The narrower `allow-private-module-inception` Clippy configuration does not cover this case because the containing `once` module is public, even though its same-named child module is private.

## Validation

- `cargo x lint`
