### PR TITLE
test: add multithreaded contention benchmarks

### DIFF
--- a/benchmarks/once_map.rs
+++ b/benchmarks/once_map.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::cell::Cell;
+
 use asyncband::once::OnceMap;
 use divan::Bencher;
 use divan::black_box;
@@ -24,10 +26,17 @@ use super::support::defer_input_drop;
 use super::support::poll_pending;
 use super::support::poll_pinned_ready;
 use super::support::poll_ready;
+use super::support::spin_poll_ready;
+use super::support::thread_slot_ticket;
 use super::support::wait_until_open;
+use super::support::yield_polls;
 
 const CACHED_ENTRY_COUNTS: &[usize] = &[0, 64, 1024];
 const WAITER_COUNTS: &[usize] = &[1, 8, 32];
+const CONTENDED_ENTRY_COUNTS: &[usize] = &[64, 1024];
+const THREAD_COUNTS: &[usize] = &[1, 2, 8, 32];
+const MISS_KEY_SPAN: usize = 1 << 16;
+const COALESCED_LEADER_POLLS: usize = 32;
 
 #[divan::bench]
 fn compute_vacant(bencher: Bencher) {
@@ -103,4 +112,118 @@ fn coalesced_compute_batch(bencher: Bencher, waiter_count: usize) {
         }
     });
 }
-use std::cell::Cell;
+
+fn preloaded_map(cached_entries: usize) -> OnceMap<usize, usize> {
+    (0..cached_entries).map(|key| (key, key)).collect()
+}
+
+// The contended benches share one map across OS threads and spread keys with thread_slot_ticket,
+// so "disjoint" means threads mostly touch different keys at any moment rather than strict
+// per-thread key ownership.
+#[divan::bench(threads = THREAD_COUNTS)]
+fn contended_get_hit_same_key(bencher: Bencher) {
+    let map = [(0, 1)].into_iter().collect::<OnceMap<_, _>>();
+
+    bencher.bench(|| black_box(map.get(black_box(&0))));
+}
+
+#[divan::bench(threads = THREAD_COUNTS, args = CONTENDED_ENTRY_COUNTS)]
+fn contended_get_hit_disjoint(bencher: Bencher, cached_entries: usize) {
+    let map = preloaded_map(cached_entries);
+
+    bencher.bench(|| {
+        let (slot, ticket) = thread_slot_ticket();
+        let key = (slot + ticket) % cached_entries;
+        black_box(map.get(black_box(&key)))
+    });
+}
+
+#[divan::bench(threads = THREAD_COUNTS)]
+fn contended_compute_hit_same_key(bencher: Bencher) {
+    let map = [(0, 1)].into_iter().collect::<OnceMap<_, _>>();
+
+    bencher.bench(|| {
+        let mut context = bench_context();
+        black_box(spin_poll_ready(
+            map.compute(black_box(0), || async { unreachable!() }),
+            &mut context,
+        ))
+    });
+}
+
+#[divan::bench(threads = THREAD_COUNTS, args = CONTENDED_ENTRY_COUNTS)]
+fn contended_compute_hit_disjoint(bencher: Bencher, cached_entries: usize) {
+    let map = preloaded_map(cached_entries);
+
+    bencher.bench(|| {
+        let mut context = bench_context();
+        let (slot, ticket) = thread_slot_ticket();
+        let key = (slot + ticket) % cached_entries;
+        black_box(spin_poll_ready(
+            map.compute(black_box(key), || async { unreachable!() }),
+            &mut context,
+        ))
+    });
+}
+
+#[divan::bench(threads = THREAD_COUNTS, args = CONTENDED_ENTRY_COUNTS)]
+fn contended_compute_miss_churn(bencher: Bencher, cached_entries: usize) {
+    let map = preloaded_map(cached_entries);
+
+    bencher.bench(|| {
+        let mut context = bench_context();
+        let (slot, ticket) = thread_slot_ticket();
+        let key = cached_entries + slot * MISS_KEY_SPAN + ticket % MISS_KEY_SPAN;
+        let value = spin_poll_ready(
+            map.compute(black_box(key), || async move { key }),
+            &mut context,
+        );
+        map.discard(&key);
+        black_box(value)
+    });
+}
+
+#[divan::bench(threads = THREAD_COUNTS, args = CONTENDED_ENTRY_COUNTS)]
+fn contended_compute_mixed(bencher: Bencher, cached_entries: usize) {
+    let map = preloaded_map(cached_entries);
+
+    bencher.bench(|| {
+        let mut context = bench_context();
+        let (slot, ticket) = thread_slot_ticket();
+        if ticket % 2 == 0 {
+            let key = (slot + ticket / 2) % cached_entries;
+            black_box(spin_poll_ready(
+                map.compute(black_box(key), || async { unreachable!() }),
+                &mut context,
+            ))
+        } else {
+            let key = cached_entries + slot * MISS_KEY_SPAN + (ticket / 2) % MISS_KEY_SPAN;
+            let value = spin_poll_ready(
+                map.compute(black_box(key), || async move { key }),
+                &mut context,
+            );
+            map.discard(&key);
+            black_box(value)
+        }
+    });
+}
+
+// The leader stays in flight for several polls so calls on other threads coalesce as duplicate
+// waiters, and discards the key while in flight so every cycle re-runs the vacant-leader path
+// instead of settling into steady-state hits.
+#[divan::bench(threads = THREAD_COUNTS)]
+fn contended_compute_coalesced(bencher: Bencher) {
+    let map = OnceMap::<usize, usize>::new();
+
+    bencher.bench(|| {
+        let mut context = bench_context();
+        black_box(spin_poll_ready(
+            map.compute(black_box(0), || async {
+                yield_polls(COALESCED_LEADER_POLLS).await;
+                map.discard(&0);
+                black_box(1)
+            }),
+            &mut context,
+        ))
+    });
+}

--- a/benchmarks/singleflight.rs
+++ b/benchmarks/singleflight.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::cell::Cell;
+
 use asyncband::singleflight::Group;
 use divan::Bencher;
 use divan::black_box;
@@ -24,9 +26,15 @@ use super::support::defer_input_drop;
 use super::support::poll_pending;
 use super::support::poll_pinned_ready;
 use super::support::poll_ready;
+use super::support::spin_poll_ready;
+use super::support::thread_slot_ticket;
 use super::support::wait_until_open;
+use super::support::yield_polls;
 
 const WAITER_COUNTS: &[usize] = &[1, 8, 32];
+const THREAD_COUNTS: &[usize] = &[1, 2, 8, 32];
+const DISJOINT_KEY_SPAN: usize = 1 << 16;
+const COALESCED_LEADER_POLLS: usize = 32;
 
 #[divan::bench]
 fn work_ready(bencher: Bencher) {
@@ -84,4 +92,49 @@ fn coalesced_work_batch(bencher: Bencher, waiter_count: usize) {
         }
     });
 }
-use std::cell::Cell;
+
+#[divan::bench(threads = THREAD_COUNTS)]
+fn contended_work_same_key(bencher: Bencher) {
+    let group = Group::<usize, usize>::new();
+
+    bencher.bench(|| {
+        let mut context = bench_context();
+        black_box(spin_poll_ready(
+            group.work(black_box(0), || async { black_box(1) }),
+            &mut context,
+        ))
+    });
+}
+
+// The leader stays in flight for several polls so calls on other threads coalesce as duplicate
+// waiters instead of leading their own cycles.
+#[divan::bench(threads = THREAD_COUNTS)]
+fn contended_work_coalesced(bencher: Bencher) {
+    let group = Group::<usize, usize>::new();
+
+    bencher.bench(|| {
+        let mut context = bench_context();
+        black_box(spin_poll_ready(
+            group.work(black_box(0), || async {
+                yield_polls(COALESCED_LEADER_POLLS).await;
+                black_box(1)
+            }),
+            &mut context,
+        ))
+    });
+}
+
+#[divan::bench(threads = THREAD_COUNTS)]
+fn contended_work_disjoint_churn(bencher: Bencher) {
+    let group = Group::<usize, usize>::new();
+
+    bencher.bench(|| {
+        let mut context = bench_context();
+        let (slot, ticket) = thread_slot_ticket();
+        let key = slot * DISJOINT_KEY_SPAN + ticket % DISJOINT_KEY_SPAN;
+        black_box(spin_poll_ready(
+            group.work(black_box(key), || async move { key }),
+            &mut context,
+        ))
+    });
+}

--- a/benchmarks/support.rs
+++ b/benchmarks/support.rs
@@ -22,6 +22,8 @@ use std::pin::Pin;
 use std::pin::pin;
 use std::sync::Arc;
 use std::sync::LazyLock;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 use std::task::Context;
 use std::task::Poll;
 use std::task::Wake;
@@ -59,6 +61,53 @@ pub(super) fn poll_pinned_ready<F: Future>(
 
 pub(super) fn poll_pending<F: Future>(mut future: Pin<&mut F>, context: &mut Context<'_>) {
     assert!(future.as_mut().poll(context).is_pending());
+}
+
+// Polls the future to completion, yielding between polls so a leader running on another thread can
+// make progress. The bench waker never wakes, so pending futures must be re-polled unconditionally.
+pub(super) fn spin_poll_ready<F: Future>(future: F, context: &mut Context<'_>) -> F::Output {
+    let mut future = pin!(future);
+    loop {
+        match future.as_mut().poll(context) {
+            Poll::Ready(output) => return output,
+            Poll::Pending => std::thread::yield_now(),
+        }
+    }
+}
+
+static NEXT_THREAD_SLOT: AtomicUsize = AtomicUsize::new(0);
+
+thread_local! {
+    static THREAD_SLOT: usize = NEXT_THREAD_SLOT.fetch_add(1, Ordering::Relaxed);
+    static THREAD_TICKET: Cell<usize> = const { Cell::new(0) };
+}
+
+// Key derivation for the contended benches: a shared counter would itself be a cross-thread
+// contention point inside the timed loop, so keys derive from a slot that is distinct for every OS
+// thread and a ticket that counts this thread's calls.
+pub(super) fn thread_slot_ticket() -> (usize, usize) {
+    let slot = THREAD_SLOT.with(|slot| *slot);
+    let ticket = THREAD_TICKET.with(|ticket| {
+        let current = ticket.get();
+        ticket.set(current.wrapping_add(1));
+        current
+    });
+    (slot, ticket)
+}
+
+// Stays pending for the given number of polls without registering a waker, so it must only be
+// polled through spin_poll_ready. Keeps a leader in flight long enough for calls on other threads
+// to join as waiters.
+pub(super) async fn yield_polls(mut polls: usize) {
+    poll_fn(move |_| {
+        if polls == 0 {
+            Poll::Ready(())
+        } else {
+            polls -= 1;
+            Poll::Pending
+        }
+    })
+    .await
 }
 
 // Move the input into the benchmark output so Divan drops it outside the timed section.


### PR DESCRIPTION
## Summary

Part 1 of #200. The existing `once_map` and `singleflight` benchmarks are single-threaded (`bench_local`), so they cannot observe cross-thread contention on the table-wide mutex. This PR adds `contended_*` benchmarks that share one map or group across OS threads via divan's `threads` option. No implementation change is included; the numbers below are the baseline for evaluating the lock designs listed in the issue.

The benches cover the workload dimensions from the issue, each at thread counts 1/2/8/32. For `OnceMap`: read-only and compute hits on a same key and on disjoint keys, miss churn, and mixed hit/miss traffic, at two preloaded table sizes. For `singleflight`: same-key traffic, disjoint-key churn, and a duplicate-waiter workload.

Two measurement details affect how to read the numbers.

Keys derive from a per-thread slot and ticket rather than a shared atomic counter, so the timed loop introduces no cross-thread contention of its own that would cap the improvement a future lock change could show.

The `*_coalesced` benches keep the leader in flight for several polls, so calls on other threads genuinely join as duplicate waiters. Since the harness polls with a no-op waker, futures are spin-polled between yields, which means waiter-heavy numbers include spin/scheduling cost rather than wake latency.

## Environment and results

- CPU: AMD Ryzen 7 5700X, 8 cores / 16 threads
- OS: Windows 11 Pro
- Toolchain: rustc 1.96.0, divan 0.1.21 with default sampling
- Command: `cargo bench --bench benchmarks -- contended`

This machine has 16 logical CPUs, so t=32 is oversubscribed: the OS scheduler serializes threads, which deflates medians while the means keep heavy tails. t=8 is the effective contention point in this run.

Key medians at that contention point:

| Benchmark | t=1 | t=8 | Slowdown |
|---|---|---|---|
| `once_map::contended_get_hit_same_key` | 13 ns | 487 ns | ~37x |
| `once_map::contended_get_hit_disjoint` (1024) | 18.5 ns | 915 ns | ~49x |
| `once_map::contended_compute_hit_same_key` | 25 ns | 819 ns | ~32x |
| `once_map::contended_compute_miss_churn` (1024) | 114 ns | 1.01 µs | ~9x |
| `singleflight::contended_work_same_key` | 99 ns | 694 ns | ~7x |
| `singleflight::contended_work_disjoint_churn` | 115 ns | 600 ns | ~5x |

The read path suffers the most even though it is read-only traffic, which matches the issue's motivation for an `RwLock` read fast path or sharding. Write-heavy singleflight traffic degrades less steeply because every call already pays for an insert and a removal.

The `*_coalesced` benches stay flat at roughly 7.5–8.6 µs across all thread counts, dominated by the leader's in-flight window. This confirms that duplicate calls genuinely coalesce as cross-thread waiters instead of multiplying work.

<details>
<summary>Full divan output (unrelated <code>mutex</code>/<code>pool</code> rows matched by the filter omitted)</summary>

```
Timer precision: 100 ns
benchmarks                            fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ once_map                                         │               │               │               │         │
│  ├─ contended_compute_coalesced                   │               │               │               │         │
│  │  ├─ t=1                          7.499 µs      │ 19.59 µs      │ 7.599 µs      │ 7.718 µs      │ 100     │ 100
│  │  ├─ t=2                          7.399 µs      │ 11.89 µs      │ 7.699 µs      │ 7.789 µs      │ 100     │ 100
│  │  ├─ t=8                          1.299 µs      │ 18.89 µs      │ 8.599 µs      │ 8.576 µs      │ 104     │ 104
│  │  ╰─ t=32                         1.099 µs      │ 10.39 µs      │ 7.949 µs      │ 6.209 µs      │ 128     │ 128
│  ├─ contended_compute_hit_disjoint                │               │               │               │         │
│  │  ├─ 64                                         │               │               │               │         │
│  │  │  ├─ t=1                       28.89 ns      │ 29.28 ns      │ 29.08 ns      │ 29.03 ns      │ 100     │ 51200
│  │  │  ├─ t=2                       31.82 ns      │ 171.6 ns      │ 153.6 ns      │ 149.9 ns      │ 100     │ 12800
│  │  │  ├─ t=8                       37.29 ns      │ 1.362 µs      │ 246.6 ns      │ 351.1 ns      │ 104     │ 1664
│  │  │  ╰─ t=32                      31.04 ns      │ 4.949 µs      │ 1.331 µs      │ 1.394 µs      │ 128     │ 4096
│  │  ╰─ 1024                                       │               │               │               │         │
│  │     ├─ t=1                       30.06 ns      │ 46.66 ns      │ 30.45 ns      │ 30.58 ns      │ 100     │ 51200
│  │     ├─ t=2                       140.4 ns      │ 341.9 ns      │ 178.6 ns      │ 180.1 ns      │ 100     │ 6400
│  │     ├─ t=8                       37.29 ns      │ 1.568 µs      │ 449.7 ns      │ 537.7 ns      │ 104     │ 1664
│  │     ╰─ t=32                      37.29 ns      │ 3.474 µs      │ 74.79 ns      │ 389.5 ns      │ 128     │ 1024
│  ├─ contended_compute_hit_same_key                │               │               │               │         │
│  │  ├─ t=1                          24.79 ns      │ 25.76 ns      │ 25.57 ns      │ 25.38 ns      │ 100     │ 51200
│  │  ├─ t=2                          78.69 ns      │ 190.4 ns      │ 129.8 ns      │ 129 ns        │ 100     │ 12800
│  │  ├─ t=8                          88.85 ns      │ 1.152 µs      │ 819.3 ns      │ 784.1 ns      │ 104     │ 6656
│  │  ╰─ t=32                         24.79 ns      │ 4.527 µs      │ 1.143 µs      │ 1.179 µs      │ 128     │ 4096
│  ├─ contended_compute_miss_churn                  │               │               │               │         │
│  │  ├─ 64                                         │               │               │               │         │
│  │  │  ├─ t=1                       111.5 ns      │ 156 ns        │ 113 ns        │ 113.9 ns      │ 100     │ 12800
│  │  │  ├─ t=2                       412.2 ns      │ 615.4 ns      │ 504.4 ns      │ 515.5 ns      │ 100     │ 3200
│  │  │  ├─ t=8                       174.7 ns      │ 4.237 µs      │ 2.012 µs      │ 1.998 µs      │ 104     │ 832
│  │  │  ╰─ t=32                      149.7 ns      │ 4.474 µs      │ 262.2 ns      │ 814.2 ns      │ 128     │ 1024
│  │  ╰─ 1024                                       │               │               │               │         │
│  │     ├─ t=1                       112.2 ns      │ 115.4 ns      │ 113.8 ns      │ 114.1 ns      │ 100     │ 12800
│  │     ├─ t=2                       434.1 ns      │ 646.6 ns      │ 565.4 ns      │ 568 ns        │ 100     │ 3200
│  │     ├─ t=8                       174.7 ns      │ 12.47 µs      │ 1.012 µs      │ 2.119 µs      │ 104     │ 416
│  │     ╰─ t=32                      174.7 ns      │ 13.34 µs      │ 1.237 µs      │ 2.757 µs      │ 128     │ 512
│  ├─ contended_compute_mixed                       │               │               │               │         │
│  │  ├─ 64                                         │               │               │               │         │
│  │  │  ├─ t=1                       71.27 ns      │ 205.2 ns      │ 72.05 ns      │ 73.59 ns      │ 100     │ 25600
│  │  │  ├─ t=2                       265.4 ns      │ 427.9 ns      │ 346.6 ns      │ 349.7 ns      │ 100     │ 3200
│  │  │  ├─ t=8                       124.7 ns      │ 3.274 µs      │ 1.249 µs      │ 1.288 µs      │ 104     │ 832
│  │  │  ╰─ t=32                      99.79 ns      │ 10.72 µs      │ 181 ns        │ 1.294 µs      │ 128     │ 1024
│  │  ╰─ 1024                                       │               │               │               │         │
│  │     ├─ t=1                       73.61 ns      │ 104.4 ns      │ 74.39 ns      │ 74.75 ns      │ 100     │ 25600
│  │     ├─ t=2                       277.9 ns      │ 446.6 ns      │ 377.9 ns      │ 373.4 ns      │ 100     │ 3200
│  │     ├─ t=8                       149.7 ns      │ 5.049 µs      │ 849.7 ns      │ 1.181 µs      │ 104     │ 208
│  │     ╰─ t=32                      112.2 ns      │ 12.19 µs      │ 224.7 ns      │ 1.581 µs      │ 128     │ 1024
│  ├─ contended_get_hit_disjoint                    │               │               │               │         │
│  │  ├─ 64                                         │               │               │               │         │
│  │  │  ├─ t=1                       16.87 ns      │ 22.73 ns      │ 16.97 ns      │ 17.08 ns      │ 100     │ 102400
│  │  │  ├─ t=2                       21.66 ns      │ 312.2 ns      │ 96.66 ns      │ 98.66 ns      │ 100     │ 12800
│  │  │  ├─ t=8                       18.54 ns      │ 1.274 µs      │ 206 ns        │ 341.6 ns      │ 104     │ 1664
│  │  │  ╰─ t=32                      18.54 ns      │ 4.699 µs      │ 441.9 ns      │ 865.5 ns      │ 128     │ 4096
│  │  ╰─ 1024                                       │               │               │               │         │
│  │     ├─ t=1                       18.34 ns      │ 24.79 ns      │ 18.54 ns      │ 18.58 ns      │ 100     │ 102400
│  │     ├─ t=2                       66.97 ns      │ 135.7 ns      │ 111.5 ns      │ 108.2 ns      │ 100     │ 12800
│  │     ├─ t=8                       21.66 ns      │ 1.69 µs       │ 915.4 ns      │ 912.4 ns      │ 104     │ 3328
│  │     ╰─ t=32                      21.66 ns      │ 4.634 µs      │ 1.266 µs      │ 1.472 µs      │ 128     │ 4096
│  ╰─ contended_get_hit_same_key                    │               │               │               │         │
│     ├─ t=1                          12.97 ns      │ 13.16 ns      │ 13.07 ns      │ 13.02 ns      │ 100     │ 102400
│     ├─ t=2                          72.44 ns      │ 130.2 ns      │ 96.27 ns      │ 97.05 ns      │ 100     │ 12800
│     ├─ t=8                          12.29 ns      │ 1.381 µs      │ 487.2 ns      │ 481.5 ns      │ 104     │ 3328
│     ╰─ t=32                         12.29 ns      │ 1.771 µs      │ 15.41 ns      │ 244.2 ns      │ 128     │ 4096
╰─ singleflight                                     │               │               │               │         │
   ├─ contended_work_coalesced                      │               │               │               │         │
   │  ├─ t=1                          7.499 µs      │ 13.49 µs      │ 7.499 µs      │ 7.637 µs      │ 100     │ 100
   │  ├─ t=2                          7.449 µs      │ 7.799 µs      │ 7.649 µs      │ 7.625 µs      │ 100     │ 200
   │  ├─ t=8                          5.099 µs      │ 12.89 µs      │ 8.099 µs      │ 8.468 µs      │ 104     │ 208
   │  ╰─ t=32                         4.549 µs      │ 58.19 µs      │ 7.049 µs      │ 15.24 µs      │ 128     │ 256
   ├─ contended_work_disjoint_churn                 │               │               │               │         │
   │  ├─ t=1                          113 ns        │ 181 ns        │ 115.4 ns      │ 117.2 ns      │ 100     │ 12800
   │  ├─ t=2                          331 ns        │ 812.2 ns      │ 427.9 ns      │ 439.2 ns      │ 100     │ 3200
   │  ├─ t=8                          299.7 ns      │ 12.69 µs      │ 599.7 ns      │ 1.132 µs      │ 104     │ 104
   │  ╰─ t=32                         137.2 ns      │ 3.737 µs      │ 206 ns        │ 707.5 ns      │ 128     │ 1024
   ╰─ contended_work_same_key                       │               │               │               │         │
      ├─ t=1                          97.44 ns      │ 100.5 ns      │ 99 ns         │ 98.86 ns      │ 100     │ 12800
      ├─ t=2                          287.2 ns      │ 493.5 ns      │ 374.7 ns      │ 375.5 ns      │ 100     │ 3200
      ├─ t=8                          124.7 ns      │ 3.337 µs      │ 693.5 ns      │ 919.1 ns      │ 104     │ 832
      ╰─ t=32                         106 ns        │ 2.793 µs      │ 424.7 ns      │ 611.1 ns      │ 128     │ 2048
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
