### PR TITLE
refactor(lazy-cell): relax poison flag ordering

### DIFF
--- a/asyncband/src/once/lazy_cell/mod.rs
+++ b/asyncband/src/once/lazy_cell/mod.rs
@@ -179,7 +179,8 @@ impl<T, Fut, F> LazyCell<T, Fut, F> {
     }
 
     fn assert_unpoisoned(&self) {
-        if self.poisoned.load(Ordering::Acquire) {
+        // This flag does not publish any accompanying data, so it only needs atomicity.
+        if self.poisoned.load(Ordering::Relaxed) {
             panic_poisoned();
         }
     }
@@ -464,7 +465,7 @@ struct PoisonOnPanic<'a>(&'a AtomicBool);
 impl Drop for PoisonOnPanic<'_> {
     fn drop(&mut self) {
         if std::thread::panicking() {
-            self.0.store(true, Ordering::Release);
+            self.0.store(true, Ordering::Relaxed);
         }
     }
 }


### PR DESCRIPTION
## Summary

- Use relaxed ordering for the `LazyCell` poison flag because it does not publish accompanying data.
- Keep the value publication ordering unchanged.
- Validate with `cargo x test` and `cargo x lint`.
