### PR TITLE
perf: take the keyed table read lock on hits and duplicate waiters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 * Replace `Semaphore::forget` with `Semaphore::drain_permits` and `Semaphore::forget_exact` with `Semaphore::reduce_permits`; permit-level `forget` methods are unchanged.
 * Rename `ShutdownSend` and `ShutdownRecv` to `Shutdown` and `ShutdownGuard`; rename `shutdown::new_pair` to `shutdown::new`; make `Shutdown` awaitable for requesting shutdown and awaiting completion; and rename the remaining operations to `request_shutdown`, `watch`, `into_watch`, `is_shutdown_requested`, `shutdown_requested`, and `shutdown_requested_owned`.
 * Raise the minimum supported Rust version from 1.85.0 to 1.86.0.
+* Require the hasher to be `Sync` for `OnceMap` and `singleflight::Group` to be `Sync`; lookups now hash keys under a shared read lock, so concurrent readers share the hasher. The default `RandomState` and other common hashers are unaffected.
 
 ### Bug fixes
 
@@ -31,3 +32,4 @@ All notable changes to this project will be documented in this file.
 ### Improvements
 
 * Remove the `slab` dependency in favor of a focused internal waiter arena.
+* Serve `OnceMap` and `singleflight::Group` lookups for initialized hits and duplicate waiters under a shared read lock instead of the exclusive table lock, so concurrent lookups no longer serialize.

--- a/asyncband/src/internal/mod.rs
+++ b/asyncband/src/internal/mod.rs
@@ -61,6 +61,9 @@ pub(crate) mod value_cell;
 ))]
 pub(crate) mod mutex;
 
+#[cfg(any(feature = "once-map", feature = "singleflight"))]
+pub(crate) mod rwlock;
+
 #[cfg(any(
     feature = "mpsc",
     feature = "mutex",

--- a/asyncband/src/internal/rwlock.rs
+++ b/asyncband/src/internal/rwlock.rs
@@ -1,0 +1,62 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::fmt;
+use std::sync::PoisonError;
+
+pub struct RwLock<T: ?Sized>(std::sync::RwLock<T>);
+
+impl<T: ?Sized + fmt::Debug> fmt::Debug for RwLock<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<T> RwLock<T> {
+    pub const fn new(t: T) -> Self {
+        Self(std::sync::RwLock::new(t))
+    }
+
+    pub fn read(&self) -> std::sync::RwLockReadGuard<'_, T> {
+        self.0.read().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    pub fn write(&self) -> std::sync::RwLockWriteGuard<'_, T> {
+        self.0.write().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::internal::rwlock::RwLock;
+
+    #[test]
+    fn test_poison_rwlock() {
+        let rwlock = Arc::new(RwLock::new(42));
+        let r = rwlock.clone();
+        let handle = std::thread::spawn(move || {
+            let _guard = r.write();
+            panic!("poison");
+        });
+        let _ = handle.join();
+        assert_eq!(*rwlock.read(), 42);
+        let guard = rwlock.write();
+        assert_eq!(*guard, 42);
+    }
+}

--- a/asyncband/src/once/once_map/mod.rs
+++ b/asyncband/src/once/once_map/mod.rs
@@ -21,9 +21,9 @@ use std::hash::Hash;
 use std::hash::RandomState;
 use std::sync::Arc;
 
-use crate::internal::mutex::Mutex;
 use crate::internal::once_table::OnceTable;
 use crate::internal::once_table::OnceTableEntry;
+use crate::internal::rwlock::RwLock;
 
 #[cfg(test)]
 mod tests;
@@ -34,7 +34,7 @@ mod tests;
 /// to wrap the `V` in an `Arc<V>` to make cloning cheap.
 #[derive(Debug)]
 pub struct OnceMap<K, V, S = RandomState> {
-    map: Mutex<OnceTable<K, V, S>>,
+    map: RwLock<OnceTable<K, V, S>>,
 }
 
 // Holds one call's entry so Drop can clean it up if the computation is abandoned.
@@ -78,9 +78,12 @@ where
             return;
         };
 
-        let mut table = self.once_map.map.lock();
+        let mut table = self.once_map.map.write();
         // If the table still owns this entry, a count of two means the current call is its only
-        // owner outside the table. remove_entry rejects an entry that was detached or replaced.
+        // owner outside the table: entries are only cloned out of the table under the table lock,
+        // so the write lock excludes new owners while the count is checked, and owners that
+        // release outside the lock do so only after the cell is initialized or the entry was
+        // detached. remove_entry rejects an entry that was detached or replaced.
         if Arc::strong_count(&entry) == 2 && !entry.initialized() {
             table.remove_entry(&entry);
         }
@@ -109,14 +112,14 @@ where
     /// Creates a new OnceMap with the default hasher.
     pub fn new() -> Self {
         Self {
-            map: Mutex::new(OnceTable::with_hasher(RandomState::new())),
+            map: RwLock::new(OnceTable::with_hasher(RandomState::new())),
         }
     }
 
     /// Creates a new OnceMap with the default hasher and the specified capacity.
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            map: Mutex::new(OnceTable::with_capacity_and_hasher(
+            map: RwLock::new(OnceTable::with_capacity_and_hasher(
                 capacity,
                 RandomState::new(),
             )),
@@ -133,15 +136,29 @@ where
     /// Creates a new OnceMap with the given hasher.
     pub fn with_hasher(hasher: S) -> Self {
         Self {
-            map: Mutex::new(OnceTable::with_hasher(hasher)),
+            map: RwLock::new(OnceTable::with_hasher(hasher)),
         }
     }
 
     /// Create a OnceMap with the specified capacity and hasher.
     pub fn with_capacity_and_hasher(capacity: usize, hasher: S) -> Self {
         Self {
-            map: Mutex::new(OnceTable::with_capacity_and_hasher(capacity, hasher)),
+            map: RwLock::new(OnceTable::with_capacity_and_hasher(capacity, hasher)),
         }
+    }
+
+    // Looks the key up under the read lock so initialized hits and duplicate waiters stay off the
+    // exclusive lock, and inserts under the write lock only when the key is absent.
+    fn compute_entry(&self, key: K) -> Arc<OnceTableEntry<K, V>> {
+        {
+            let map = self.map.read();
+            if let Some(entry) = map.get(&key) {
+                return Arc::clone(entry);
+            }
+        }
+
+        let mut map = self.map.write();
+        Arc::clone(map.get_or_insert(key))
     }
 
     /// Compute the value for the given key if absent.
@@ -155,14 +172,10 @@ where
     where
         F: AsyncFnOnce() -> V,
     {
-        let entry = {
-            let mut map = self.map.lock();
-            let entry = map.get_or_insert(key);
-            if let Some(value) = entry.get() {
-                return value.clone();
-            }
-            Arc::clone(entry)
-        };
+        let entry = self.compute_entry(key);
+        if let Some(value) = entry.get() {
+            return value.clone();
+        }
 
         let guard = ComputeCleanupGuard::new(self, entry);
         let result = guard.entry().get_or_init(func).await.clone();
@@ -181,14 +194,10 @@ where
     where
         F: AsyncFnOnce() -> Result<V, E>,
     {
-        let entry = {
-            let mut map = self.map.lock();
-            let entry = map.get_or_insert(key);
-            if let Some(value) = entry.get() {
-                return Ok(value.clone());
-            }
-            Arc::clone(entry)
-        };
+        let entry = self.compute_entry(key);
+        if let Some(value) = entry.get() {
+            return Ok(value.clone());
+        }
 
         let guard = ComputeCleanupGuard::new(self, entry);
         let result = guard.entry().get_or_try_init(func).await?.clone();
@@ -202,7 +211,7 @@ where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        let map = self.map.lock();
+        let map = self.map.read();
         let entry = map.get(key)?;
         entry.get().cloned()
     }
@@ -217,7 +226,7 @@ where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        let mut map = self.map.lock();
+        let mut map = self.map.write();
         map.remove(key);
     }
 
@@ -232,7 +241,7 @@ where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        let entry = self.map.lock().remove(key)?;
+        let entry = self.map.write().remove(key)?;
         entry.get().cloned()
     }
 }
@@ -250,7 +259,7 @@ where
         }
 
         Self {
-            map: Mutex::new(map),
+            map: RwLock::new(map),
         }
     }
 }

--- a/asyncband/src/once/once_map/mod.rs
+++ b/asyncband/src/once/once_map/mod.rs
@@ -93,6 +93,13 @@ where
     }
 }
 
+// Outcome of looking a key up for compute: an initialized entry resolves to its value while the
+// table lock is still held, so contended hits never touch the entry's shared reference count.
+enum ComputeLookup<K, V> {
+    Hit(V),
+    Pending(Arc<OnceTableEntry<K, V>>),
+}
+
 impl<K, V, S> Default for OnceMap<K, V, S>
 where
     K: Eq + Hash,
@@ -149,16 +156,23 @@ where
 
     // Looks the key up under the read lock so initialized hits and duplicate waiters stay off the
     // exclusive lock, and inserts under the write lock only when the key is absent.
-    fn compute_entry(&self, key: K) -> Arc<OnceTableEntry<K, V>> {
+    fn compute_entry(&self, key: K) -> ComputeLookup<K, V> {
         {
             let map = self.map.read();
             if let Some(entry) = map.get(&key) {
-                return Arc::clone(entry);
+                if let Some(value) = entry.get() {
+                    return ComputeLookup::Hit(value.clone());
+                }
+                return ComputeLookup::Pending(Arc::clone(entry));
             }
         }
 
         let mut map = self.map.write();
-        Arc::clone(map.get_or_insert(key))
+        let entry = map.get_or_insert(key);
+        if let Some(value) = entry.get() {
+            return ComputeLookup::Hit(value.clone());
+        }
+        ComputeLookup::Pending(Arc::clone(entry))
     }
 
     /// Compute the value for the given key if absent.
@@ -172,10 +186,10 @@ where
     where
         F: AsyncFnOnce() -> V,
     {
-        let entry = self.compute_entry(key);
-        if let Some(value) = entry.get() {
-            return value.clone();
-        }
+        let entry = match self.compute_entry(key) {
+            ComputeLookup::Hit(value) => return value,
+            ComputeLookup::Pending(entry) => entry,
+        };
 
         let guard = ComputeCleanupGuard::new(self, entry);
         let result = guard.entry().get_or_init(func).await.clone();
@@ -194,10 +208,10 @@ where
     where
         F: AsyncFnOnce() -> Result<V, E>,
     {
-        let entry = self.compute_entry(key);
-        if let Some(value) = entry.get() {
-            return Ok(value.clone());
-        }
+        let entry = match self.compute_entry(key) {
+            ComputeLookup::Hit(value) => return Ok(value),
+            ComputeLookup::Pending(entry) => entry,
+        };
 
         let guard = ComputeCleanupGuard::new(self, entry);
         let result = guard.entry().get_or_try_init(func).await?.clone();

--- a/asyncband/src/once/once_map/tests.rs
+++ b/asyncband/src/once/once_map/tests.rs
@@ -29,7 +29,7 @@ async fn failed_compute_removes_empty_entry() {
     let result: Result<i32, &str> = map.try_compute("key", async || Err("fail")).await;
 
     assert_eq!(result, Err("fail"));
-    assert!(map.map.lock().is_empty());
+    assert!(map.map.read().is_empty());
 }
 
 #[tokio::test]
@@ -46,7 +46,7 @@ async fn panicked_compute_removes_empty_entry() {
     });
 
     assert!(task.await.unwrap_err().is_panic());
-    assert!(map.map.lock().is_empty());
+    assert!(map.map.read().is_empty());
 }
 
 #[tokio::test]
@@ -65,11 +65,78 @@ async fn cancelled_compute_removes_empty_entry() {
     });
 
     started_rx.await.unwrap();
-    assert_eq!(map.map.lock().len(), 1);
+    assert_eq!(map.map.read().len(), 1);
 
     task.abort();
     assert!(task.await.unwrap_err().is_cancelled());
-    assert!(map.map.lock().is_empty());
+    assert!(map.map.read().is_empty());
+}
+
+#[tokio::test]
+async fn cancelled_waiter_preserves_pending_entry() {
+    let map = OnceMap::<&str, i32>::new();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+
+    let leader = map.compute("key", async move || {
+        release_rx.await.unwrap();
+        1
+    });
+    tokio::pin!(leader);
+    assert!(poll_once(leader.as_mut()).is_pending());
+
+    let mut waiter = Box::pin(map.compute("key", async || unreachable!()));
+    assert!(poll_once(waiter.as_mut()).is_pending());
+    drop(waiter);
+
+    assert_eq!(map.map.read().len(), 1);
+
+    release_tx.send(()).unwrap();
+    assert_eq!(leader.await, 1);
+    assert_eq!(map.get("key"), Some(1));
+}
+
+#[tokio::test]
+async fn cancelled_waiter_preserves_initialized_entry() {
+    let map = OnceMap::<&str, i32>::new();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+
+    let leader = map.compute("key", async move || {
+        release_rx.await.unwrap();
+        1
+    });
+    tokio::pin!(leader);
+    assert!(poll_once(leader.as_mut()).is_pending());
+
+    let mut waiter = Box::pin(map.compute("key", async || unreachable!()));
+    assert!(poll_once(waiter.as_mut()).is_pending());
+
+    release_tx.send(()).unwrap();
+    assert_eq!(leader.await, 1);
+
+    drop(waiter);
+
+    assert_eq!(map.map.read().len(), 1);
+    assert_eq!(map.get("key"), Some(1));
+}
+
+#[tokio::test]
+async fn cancelled_compute_preserves_replacement_entry() {
+    let map = OnceMap::<&str, i32>::new();
+    let (_release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+
+    let mut first = Box::pin(map.compute("key", async move || {
+        release_rx.await.unwrap();
+        1
+    }));
+    assert!(poll_once(first.as_mut()).is_pending());
+
+    map.discard("key");
+    assert_eq!(map.compute("key", async || 2).await, 2);
+
+    drop(first);
+
+    assert_eq!(map.map.read().len(), 1);
+    assert_eq!(map.get("key"), Some(2));
 }
 
 #[tokio::test]
@@ -91,7 +158,7 @@ async fn failed_compute_preserves_entry_for_waiter_retry() {
     release_tx.send(()).unwrap();
     assert_eq!(first.await, Err("fail"));
 
-    assert_eq!(map.map.lock().len(), 1);
+    assert_eq!(map.map.read().len(), 1);
     assert_eq!(retry.await, Ok(1));
     assert_eq!(map.get("key"), Some(1));
 }

--- a/asyncband/src/singleflight/mod.rs
+++ b/asyncband/src/singleflight/mod.rs
@@ -23,9 +23,9 @@ use std::hash::Hash;
 use std::hash::RandomState;
 use std::sync::Arc;
 
-use crate::internal::mutex::Mutex;
 use crate::internal::once_table::OnceTable;
 use crate::internal::once_table::OnceTableEntry;
+use crate::internal::rwlock::RwLock;
 
 #[cfg(test)]
 mod tests;
@@ -34,7 +34,7 @@ mod tests;
 /// units of work can be executed with duplicate suppression.
 #[derive(Debug)]
 pub struct Group<K, V, S = RandomState> {
-    map: Mutex<OnceTable<K, V, S>>,
+    map: RwLock<OnceTable<K, V, S>>,
 }
 
 // Holds one call's entry so Drop can clean it up if the work is abandoned.
@@ -53,9 +53,15 @@ where
     S: BuildHasher,
 {
     fn new(group: &'a Group<K, V, S>, key: K) -> Self {
+        // Looks the key up under the read lock so duplicate waiters stay off the exclusive lock,
+        // and inserts under the write lock only when no call is in flight for the key.
         let entry = {
-            let mut map = group.map.lock();
-            Arc::clone(map.get_or_insert(key))
+            let map = group.map.read();
+            map.get(&key).map(Arc::clone)
+        };
+        let entry = match entry {
+            Some(entry) => entry,
+            None => Arc::clone(group.map.write().get_or_insert(key)),
         };
 
         Self {
@@ -83,9 +89,12 @@ where
             return;
         };
 
-        let mut table = self.group.map.lock();
+        let mut table = self.group.map.write();
         // If the table still owns this entry, a count of two means the current call is its only
-        // owner outside the table. remove_entry rejects an entry that was detached or replaced.
+        // owner outside the table: entries are only cloned out of the table under the table lock,
+        // so the write lock excludes new owners while the count is checked, and owners that
+        // release outside the lock do so only after the cell is initialized or the entry was
+        // detached. remove_entry rejects an entry that was detached or replaced.
         if Arc::strong_count(&entry) == 2 && !entry.initialized() {
             table.remove_entry(&entry);
         }
@@ -114,7 +123,7 @@ where
     /// Creates a new Group with the default hasher.
     pub fn new() -> Self {
         Self {
-            map: Mutex::new(OnceTable::with_hasher(RandomState::new())),
+            map: RwLock::new(OnceTable::with_hasher(RandomState::new())),
         }
     }
 }
@@ -128,7 +137,7 @@ where
     /// Creates a new Group with the given hasher.
     pub fn with_hasher(hasher: S) -> Self {
         Self {
-            map: Mutex::new(OnceTable::with_hasher(hasher)),
+            map: RwLock::new(OnceTable::with_hasher(hasher)),
         }
     }
 
@@ -193,7 +202,7 @@ where
         let result = entry
             .get_or_init(async || {
                 let result = func().await;
-                self.map.lock().remove_entry(entry);
+                self.map.write().remove_entry(entry);
                 result
             })
             .await
@@ -257,7 +266,7 @@ where
         let result = entry
             .get_or_try_init(async || {
                 let result = func().await?;
-                self.map.lock().remove_entry(entry);
+                self.map.write().remove_entry(entry);
                 Ok(result)
             })
             .await?
@@ -275,7 +284,7 @@ where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        let mut map = self.map.lock();
+        let mut map = self.map.write();
         map.remove(key);
     }
 }

--- a/asyncband/src/singleflight/tests.rs
+++ b/asyncband/src/singleflight/tests.rs
@@ -36,7 +36,7 @@ async fn panicked_work_removes_empty_entry() {
     });
 
     assert!(task.await.unwrap_err().is_panic());
-    assert!(group.map.lock().is_empty());
+    assert!(group.map.read().is_empty());
 
     let result = group.work("key", || async { "success".to_owned() }).await;
     assert_eq!(result, "success");
@@ -58,11 +58,63 @@ async fn cancelled_work_removes_empty_entry() {
     });
 
     started_rx.await.unwrap();
-    assert_eq!(group.map.lock().len(), 1);
+    assert_eq!(group.map.read().len(), 1);
 
     task.abort();
     assert!(task.await.unwrap_err().is_cancelled());
-    assert!(group.map.lock().is_empty());
+    assert!(group.map.read().is_empty());
+}
+
+#[tokio::test]
+async fn cancelled_waiter_preserves_inflight_entry() {
+    let group = Group::<&str, i32>::new();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+
+    let leader = group.work("key", || async move {
+        release_rx.await.unwrap();
+        1
+    });
+    tokio::pin!(leader);
+    assert!(poll_once(leader.as_mut()).is_pending());
+
+    let mut waiter = Box::pin(group.work("key", || async { unreachable!() }));
+    assert!(poll_once(waiter.as_mut()).is_pending());
+    drop(waiter);
+
+    assert_eq!(group.map.read().len(), 1);
+
+    release_tx.send(()).unwrap();
+    assert_eq!(leader.await, 1);
+    assert!(group.map.read().is_empty());
+}
+
+#[tokio::test]
+async fn cancelled_work_preserves_replacement_entry() {
+    let group = Group::<&str, i32>::new();
+    let (_release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+    let (replacement_tx, replacement_rx) = tokio::sync::oneshot::channel();
+
+    let mut first = Box::pin(group.work("key", || async move {
+        release_rx.await.unwrap();
+        1
+    }));
+    assert!(poll_once(first.as_mut()).is_pending());
+
+    group.forget("key");
+
+    let second = group.work("key", || async move {
+        replacement_rx.await.unwrap();
+        2
+    });
+    tokio::pin!(second);
+    assert!(poll_once(second.as_mut()).is_pending());
+
+    drop(first);
+    assert_eq!(group.map.read().len(), 1);
+
+    replacement_tx.send(()).unwrap();
+    assert_eq!(second.await, 2);
+    assert!(group.map.read().is_empty());
 }
 
 #[tokio::test]
@@ -73,7 +125,7 @@ async fn failed_try_work_removes_empty_entry() {
         .try_work("key", || async { Err::<&str, &str>("error") })
         .await;
     assert_eq!(result, Err("error"));
-    assert!(group.map.lock().is_empty());
+    assert!(group.map.read().is_empty());
 
     let retry = group
         .try_work("key", || async { Ok::<&str, ()>("success") })
@@ -100,7 +152,7 @@ async fn failed_try_work_preserves_entry_for_waiter_retry() {
     release_tx.send(()).unwrap();
     assert_eq!(first.await, Err("fail"));
 
-    assert_eq!(group.map.lock().len(), 1);
+    assert_eq!(group.map.read().len(), 1);
     assert_eq!(retry.await, Ok("success"));
-    assert!(group.map.lock().is_empty());
+    assert!(group.map.read().is_empty());
 }

--- a/tests-integration/tests/traits_test.rs
+++ b/tests-integration/tests/traits_test.rs
@@ -62,6 +62,19 @@ impl ManageObject for PoolManager {
     }
 }
 
+// A hasher that is Send but not Sync. OnceMap and Group hash keys under a shared read lock, so
+// being Sync requires the hasher to be Sync, while being Send does not.
+#[allow(dead_code)]
+struct SendOnlyState(std::marker::PhantomData<Cell<u64>>);
+
+impl std::hash::BuildHasher for SendOnlyState {
+    type Hasher = std::hash::DefaultHasher;
+
+    fn build_hasher(&self) -> Self::Hasher {
+        std::hash::DefaultHasher::new()
+    }
+}
+
 #[test]
 fn public_types_are_send_and_sync() {
     fn assert_send_and_sync<T: Send + Sync>() {}
@@ -104,6 +117,8 @@ fn movable_public_types_are_send() {
     fn assert_send<T: Send>() {}
 
     assert_send::<RwLockReadGuard<'_, std::sync::MutexGuard<'static, ()>>>();
+    assert_send::<OnceMap<String, u32, SendOnlyState>>();
+    assert_send::<singleflight::Group<String, u32, SendOnlyState>>();
     assert_send::<oneshot::Receiver<i64>>();
     assert_send::<oneshot::Recv<i64>>();
     assert_send::<pool::unbounded::Object<Cell<u8>>>();


### PR DESCRIPTION
# Summary

This implements step 2 of #200, using the contention baseline from #202. The keyed table shared by `OnceMap` and `singleflight::Group` moves from a single `Mutex` to an internal `RwLock`. Lookups that do not mutate the table — `OnceMap::get`, `compute` on an already-initialized entry, and a singleflight call joining an in-flight leader as a duplicate waiter — now take the read lock and run concurrently. A miss falls back to the write lock, where `get_or_insert` double-checks before inserting. Removals and the cleanup guards keep running under the write lock.

The baseline showed that read paths degrade worst under contention (about 37–49x at 8 threads for initialized hits) while write-heavy singleflight churn degrades least, so a read fast path targets exactly the measured pain. Unlike sharding, it also helps the same-key hotspot, and it leaves the `HashTable` and hasher ownership untouched. Sharding was evaluated and deferred: it cannot help same-key traffic, its benefit lands on the write-churn scenarios whose measurements are the noisiest, and it can still be layered on top of this change later if real workloads warrant it.

## Correctness

The `Arc::strong_count == 2` cleanup protocol is preserved. Entry `Arc`s are only cloned out of the table while holding the table lock, and the count check runs under the write lock, which excludes all readers, so the check can never miss a concurrent new owner. Callers that release their clone outside the lock only do so after the cell is initialized or after the entry left the table, which the existing `!initialized()` and `Arc::ptr_eq` guards already reject. No lock is held across an `.await`, and the read guard is always released before the write lock is requested.

New regression tests pin the races this design touches: a cancelled duplicate waiter must not remove an in-flight or initialized entry, and an abandoned first caller must not remove a replacement installed for the same key (via `discard` for `OnceMap` and `forget` for `Group`).

## Breaking change: `Sync` now requires the hasher to be `Sync`

`std::sync::Mutex<T>` is `Sync` when `T: Send`, but `RwLock<T>` requires `T: Sync`, so `OnceMap` and `Group` are now `Sync` only when the hasher `S` is also `Sync`. This is inherent to any design where concurrent readers hash keys through a shared `&S`, not an artifact of the implementation. The default `RandomState` and common third-party hashers are all `Sync`; a hasher that is `Send` but not `Sync` still yields a `Send` (but no longer `Sync`) map. This is recorded in the CHANGELOG, and a new trait test pins the semantics with a `Send + !Sync` hasher. Flagging it explicitly since #200 lists expected auto traits as a compatibility constraint — if this trade-off is unacceptable, the read fast path cannot be kept.

## Results

Test environment: AMD Ryzen 7 5700X (8 cores / 16 threads), Windows 11 Pro, rustc 1.96.0, divan 0.1.21, `cargo bench --bench benchmarks -- contended`. As in #202, t=8 is the meaningful contention point on this machine and t=32 medians are distorted by oversubscription.

Median time per operation at t=8, single `Mutex` baseline vs this change:

| Benchmark | Baseline | This PR | Change |
|---|---|---|---|
| `once_map::contended_get_hit_same_key` | 487 ns | 63 ns | ~7.7x faster |
| `once_map::contended_get_hit_disjoint` (1024) | 915 ns | 238 ns | ~3.8x faster |
| `once_map::contended_compute_hit_same_key` | 819 ns | 63 ns | ~13x faster |
| `once_map::contended_compute_hit_disjoint` (1024) | 450 ns | 228 ns | ~2x faster |
| `singleflight::contended_work_same_key` | 694 ns | 543 ns | on par |
| miss/churn scenarios | 0.6–2 µs | 0.7–3.9 µs | within noise |

The churn rows need the caveat spelled out: re-running the same build back to back swings their t=8 medians by up to 5x (the baseline itself measured 600 ns in one run and 1.78 µs in another for `contended_work_disjoint_churn`), and both builds land in the same band, so no regression is distinguishable from noise there. The stable cost is single-threaded: a miss now pays a read-lock probe before the write lock, which shows up as roughly +10% at t=1 on the miss/churn paths (for example `contended_compute_miss_churn` 113 ns → 127 ns). Initialized hits at t=1 are unchanged (`get` stays at 13 ns). The coalesced benches stay flat across thread counts, dominated by the leader's in-flight window as intended.

<details>
<summary>Full divan output (this PR)</summary>

```
Timer precision: 100 ns
benchmarks                            fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ once_map                                         │               │               │               │         │
│  ├─ contended_compute_coalesced                   │               │               │               │         │
│  │  ├─ t=1                          7.599 µs      │ 20.89 µs      │ 7.699 µs      │ 7.791 µs      │ 100     │ 100
│  │  ├─ t=2                          7.499 µs      │ 13.39 µs      │ 7.899 µs      │ 7.935 µs      │ 100     │ 100
│  │  ├─ t=8                          1.799 µs      │ 12.49 µs      │ 8.749 µs      │ 8.51 µs       │ 104     │ 104
│  │  ╰─ t=32                         899.7 ns      │ 11.59 µs      │ 7.999 µs      │ 6.306 µs      │ 128     │ 128
│  ├─ contended_compute_hit_disjoint                │               │               │               │         │
│  │  ├─ 64                                         │               │               │               │         │
│  │  │  ├─ t=1                       31.62 ns      │ 40.21 ns      │ 31.82 ns      │ 31.89 ns      │ 100     │ 51200
│  │  │  ├─ t=2                       76.35 ns      │ 95.88 ns      │ 88.07 ns      │ 87.41 ns      │ 100     │ 12800
│  │  │  ├─ t=8                       48.22 ns      │ 432.6 ns      │ 198.2 ns      │ 204.7 ns      │ 104     │ 6656
│  │  │  ╰─ t=32                      41.97 ns      │ 216.9 ns      │ 54.47 ns      │ 67.39 ns      │ 128     │ 8192
│  │  ╰─ 1024                                       │               │               │               │         │
│  │     ├─ t=1                       33.96 ns      │ 44.32 ns      │ 34.36 ns      │ 34.51 ns      │ 100     │ 51200
│  │     ├─ t=2                       80.25 ns      │ 106 ns        │ 93.54 ns      │ 93.37 ns      │ 100     │ 12800
│  │     ├─ t=8                       63.85 ns      │ 591.9 ns      │ 227.9 ns      │ 258.7 ns      │ 104     │ 6656
│  │     ╰─ t=32                      49.79 ns      │ 1.162 µs      │ 242.7 ns      │ 418.9 ns      │ 128     │ 8192
│  ├─ contended_compute_hit_same_key                │               │               │               │         │
│  │  ├─ t=1                          28.5 ns       │ 37.68 ns      │ 28.69 ns      │ 28.69 ns      │ 100     │ 51200
│  │  ├─ t=2                          69.32 ns      │ 252.9 ns      │ 102.1 ns      │ 102.8 ns      │ 100     │ 12800
│  │  ├─ t=8                          29.47 ns      │ 502.9 ns      │ 63.07 ns      │ 95.41 ns      │ 104     │ 6656
│  │  ╰─ t=32                         31.04 ns      │ 702.9 ns      │ 41.97 ns      │ 147.4 ns      │ 128     │ 4096
│  ├─ contended_compute_miss_churn                  │               │               │               │         │
│  │  ├─ 64                                         │               │               │               │         │
│  │  │  ├─ t=1                       125.5 ns      │ 129.4 ns      │ 127.1 ns      │ 126.7 ns      │ 100     │ 12800
│  │  │  ├─ t=2                       437.2 ns      │ 1.131 µs      │ 612.2 ns      │ 618.2 ns      │ 100     │ 1600
│  │  │  ├─ t=8                       199.7 ns      │ 7.899 µs      │ 799.7 ns      │ 1.415 µs      │ 104     │ 208
│  │  │  ╰─ t=32                      224.7 ns      │ 20.95 µs      │ 9.927 µs      │ 9.931 µs      │ 128     │ 2048
│  │  ╰─ 1024                                       │               │               │               │         │
│  │     ├─ t=1                       127.9 ns      │ 253.6 ns      │ 131 ns        │ 132.2 ns      │ 100     │ 12800
│  │     ├─ t=2                       406 ns        │ 749.7 ns      │ 602.9 ns      │ 602.9 ns      │ 100     │ 1600
│  │     ├─ t=8                       187.2 ns      │ 6.499 µs      │ 3.887 µs      │ 3.56 µs       │ 104     │ 832
│  │     ╰─ t=32                      174.7 ns      │ 28.39 µs      │ 349.7 ns      │ 4.316 µs      │ 128     │ 1024
│  ├─ contended_compute_mixed                       │               │               │               │         │
│  │  ├─ 64                                         │               │               │               │         │
│  │  │  ├─ t=1                       78.69 ns      │ 101.3 ns      │ 80.25 ns      │ 80.81 ns      │ 100     │ 12800
│  │  │  ├─ t=2                       312.2 ns      │ 427.9 ns      │ 387.2 ns      │ 388.1 ns      │ 100     │ 3200
│  │  │  ├─ t=8                       149.7 ns      │ 4.174 µs      │ 549.7 ns      │ 1.104 µs      │ 104     │ 416
│  │  │  ╰─ t=32                      112.2 ns      │ 9.699 µs      │ 868.5 ns      │ 1.922 µs      │ 128     │ 1024
│  │  ╰─ 1024                                       │               │               │               │         │
│  │     ├─ t=1                       79.47 ns      │ 82.6 ns       │ 81.04 ns      │ 80.77 ns      │ 100     │ 12800
│  │     ├─ t=2                       124.7 ns      │ 402.9 ns      │ 362.2 ns      │ 356 ns        │ 100     │ 3200
│  │     ├─ t=8                       149.7 ns      │ 4.199 µs      │ 1.799 µs      │ 1.871 µs      │ 104     │ 416
│  │     ╰─ t=32                      124.7 ns      │ 3.599 µs      │ 187.2 ns      │ 660.7 ns      │ 128     │ 1024
│  ├─ contended_get_hit_disjoint                    │               │               │               │         │
│  │  ├─ 64                                         │               │               │               │         │
│  │  │  ├─ t=1                       16.97 ns      │ 31.72 ns      │ 17.07 ns      │ 17.22 ns      │ 100     │ 102400
│  │  │  ├─ t=2                       78.69 ns      │ 99 ns         │ 87.29 ns      │ 87.75 ns      │ 100     │ 12800
│  │  │  ├─ t=8                       18.54 ns      │ 441.9 ns      │ 221.6 ns      │ 206.1 ns      │ 104     │ 6656
│  │  │  ╰─ t=32                      18.54 ns      │ 1.559 µs      │ 131 ns        │ 303.2 ns      │ 128     │ 8192
│  │  ╰─ 1024                                       │               │               │               │         │
│  │     ├─ t=1                       18.34 ns      │ 32.5 ns       │ 18.44 ns      │ 18.61 ns      │ 100     │ 102400
│  │     ├─ t=2                       28.69 ns      │ 102.9 ns      │ 87.29 ns      │ 86.43 ns      │ 100     │ 12800
│  │     ├─ t=8                       23.22 ns      │ 463.8 ns      │ 238 ns        │ 230 ns        │ 104     │ 6656
│  │     ╰─ t=32                      20.1 ns       │ 1.354 µs      │ 303.6 ns      │ 492.6 ns      │ 128     │ 8192
│  ╰─ contended_get_hit_same_key                    │               │               │               │         │
│     ├─ t=1                          12.97 ns      │ 13.16 ns      │ 13.07 ns      │ 13.04 ns      │ 100     │ 102400
│     ├─ t=2                          60.72 ns      │ 165.4 ns      │ 75.57 ns      │ 75.16 ns      │ 100     │ 25600
│     ├─ t=8                          13.85 ns      │ 257.6 ns      │ 63.07 ns      │ 84.39 ns      │ 104     │ 6656
│     ╰─ t=32                         68.54 ns      │ 1.394 µs      │ 686.5 ns      │ 627.6 ns      │ 128     │ 16384
╰─ singleflight                                     │               │               │               │         │
   ├─ contended_work_coalesced                      │               │               │               │         │
   │  ├─ t=1                          7.449 µs      │ 9.599 µs      │ 7.499 µs      │ 7.536 µs      │ 100     │ 200
   │  ├─ t=2                          7.499 µs      │ 9.049 µs      │ 7.649 µs      │ 7.67 µs       │ 100     │ 200
   │  ├─ t=8                          1.199 µs      │ 12.69 µs      │ 9.949 µs      │ 8.914 µs      │ 104     │ 104
   │  ╰─ t=32                         1.499 µs      │ 11.69 µs      │ 7.999 µs      │ 6.383 µs      │ 128     │ 128
   ├─ contended_work_disjoint_churn                 │               │               │               │         │
   │  ├─ t=1                          134.1 ns      │ 139.6 ns      │ 136.5 ns      │ 136.4 ns      │ 100     │ 12800
   │  ├─ t=2                          393.5 ns      │ 868.5 ns      │ 449.7 ns      │ 460 ns        │ 100     │ 1600
   │  ├─ t=8                          162.2 ns      │ 6.662 µs      │ 3.174 µs      │ 3.063 µs      │ 104     │ 832
   │  ╰─ t=32                         149.7 ns      │ 15.42 µs      │ 687.2 ns      │ 3.108 µs      │ 128     │ 512
   ╰─ contended_work_same_key                       │               │               │               │         │
      ├─ t=1                          109.1 ns      │ 110.7 ns      │ 109.9 ns      │ 109.9 ns      │ 100     │ 12800
      ├─ t=2                          293.5 ns      │ 449.7 ns      │ 393.5 ns      │ 390.5 ns      │ 100     │ 3200
      ├─ t=8                          124.7 ns      │ 3.237 µs      │ 543.5 ns      │ 805.3 ns      │ 104     │ 832
      ╰─ t=32                         174.7 ns      │ 10.79 µs      │ 2.012 µs      │ 2.704 µs      │ 128     │ 512
```

The baseline numbers are the ones reported in #202, measured on the same machine.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
