### PR TITLE
docs: refine 0.7 release documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,25 +6,25 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-### New features
-
-* Implement `broadcast::mpmc::unbounded`, an unbounded broadcast channel that retains messages until all active receivers consume them or are dropped.
-* Add an opt-in `asyncband::blocking::FutureExt` bridge with `block_on` and `wait_timeout` methods for waiting on runtime-agnostic futures from synchronous code.
-* Add opt-in bounded and unbounded runtime-agnostic object pools under `asyncband::pool`.
-* Add opt-in `asyncband::once::LazyCell` for values that own one asynchronous initializer and preserve its in-flight future across caller cancellation.
-* Add an opt-in latest-state channel under `asyncband::watch`.
-
 ### Breaking changes
 
 * Gate all exported primitives behind opt-in Cargo features and enable no features by default; downstream dependencies must explicitly enable the APIs they use.
+* Raise the minimum supported Rust version from 1.85.0 to 1.86.0.
 * Remove `admission::FairShare` and its `admission` Cargo feature from the feature set.
 * Remove the `asyncband::atomicbox` module and its `AtomicBox` and `AtomicOptionBox` types from the public API.
-* Remove the lossy `broadcast::overflow` channel; replacement broadcast APIs use explicit bounded and unbounded lossless semantics under the retained `broadcast` Cargo feature.
-* Remove `Semaphore::try_acquire_and_forget`, `Semaphore::acquire_and_forget`, `Semaphore::try_acquire_owned_and_forget`, and `Semaphore::acquire_owned_and_forget`; acquire a permit and call its `forget` method instead.
+* Remove the lossy `broadcast::overflow` channel; the new `broadcast::mpmc::unbounded` channel provides lossless unbounded retention under the retained `broadcast` Cargo feature.
 * Rename `oneshot::Sender::is_closed` and `oneshot::Receiver::is_closed` to `is_disconnected`.
+* Remove `Semaphore::try_acquire_and_forget`, `Semaphore::acquire_and_forget`, `Semaphore::try_acquire_owned_and_forget`, and `Semaphore::acquire_owned_and_forget`; acquire a permit and call its `forget` method instead.
 * Replace `Semaphore::forget` with `Semaphore::drain_permits` and `Semaphore::forget_exact` with `Semaphore::reduce_permits`; permit-level `forget` methods are unchanged.
 * Rename `ShutdownSend` and `ShutdownRecv` to `Shutdown` and `ShutdownGuard`; rename `shutdown::new_pair` to `shutdown::new`; make `Shutdown` awaitable for requesting shutdown and awaiting completion; and rename the remaining operations to `request_shutdown`, `watch`, `into_watch`, `is_shutdown_requested`, `shutdown_requested`, and `shutdown_requested_owned`.
-* Raise the minimum supported Rust version from 1.85.0 to 1.86.0.
+
+### New features
+
+* Implement `broadcast::mpmc::unbounded`, an unbounded broadcast channel that retains messages until all active receivers consume them or are dropped.
+* Add an opt-in latest-state channel under `asyncband::watch`.
+* Add opt-in `asyncband::once::LazyCell` for values that own one asynchronous initializer and preserve its in-flight future across caller cancellation.
+* Add opt-in bounded and unbounded runtime-agnostic object pools under `asyncband::pool`.
+* Add an opt-in `asyncband::blocking::FutureExt` bridge with `block_on` and `wait_timeout` methods for waiting on runtime-agnostic futures from synchronous code.
 
 ### Bug fixes
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ async fn increment() {
 }
 ```
 
-Public modules stay at direct crate-root paths. Related variants are grouped beneath their semantic family—for example, initialization cells under `asyncband::once` and MPMC broadcast under `asyncband::broadcast::mpmc`. Cargo features select compiled APIs; topology and bounded or unbounded policies remain module or constructor choices rather than separate features.
+Public paths stay direct—such as `asyncband::mutex`, `asyncband::pool`, and `asyncband::once::OnceCell`—while Cargo features keep unused implementations out of the build.
 
 ## Examples
 
@@ -77,7 +77,7 @@ Runnable examples live in the [`examples`](examples) workspace crate. They demon
 |                       | [`Shutdown`](https://docs.rs/asyncband/*/asyncband/shutdown/struct.Shutdown.html)    | `shutdown`     | Coordinate shutdown signals and completion.                                                            |
 | Channels              | [`oneshot`](https://docs.rs/asyncband/*/asyncband/oneshot/)                          | `oneshot`      | Send one value from one sender to one receiver.                                                         |
 |                       | [`mpsc`](https://docs.rs/asyncband/*/asyncband/mpsc/)                                | `mpsc`         | Send each value from multiple producers to one receiver through a bounded or unbounded queue.           |
-|                       | [`broadcast::mpmc`](https://docs.rs/asyncband/*/asyncband/broadcast/mpmc/)            | `broadcast`    | Broadcast every value from multiple producers to every active receiver with unbounded retention.        |
+|                       | [`broadcast`](https://docs.rs/asyncband/*/asyncband/broadcast/)                      | `broadcast`    | Broadcast values from one or more producers and retain them until every active receiver consumes them. |
 |                       | [`watch`](https://docs.rs/asyncband/*/asyncband/watch/)                              | `watch`        | Publish the latest state to independently tracked receivers and coalesce intermediate updates.          |
 | Resource reuse        | [`pool`](https://docs.rs/asyncband/*/asyncband/pool/)                                | `pool`         | Reuse objects through bounded or unbounded pool variants.                                              |
 | Workload coordination | [`Semaphore`](https://docs.rs/asyncband/*/asyncband/semaphore/struct.Semaphore.html) | `semaphore`    | Control concurrent access with permits.                                                                |
@@ -123,9 +123,9 @@ Asyncband types implement `Send` and `Sync` only when the protected, transferred
 
 ## Minimum Supported Rust Version (MSRV)
 
-Asyncband supports rustc 1.86.0 and newer. CI tests both 1.86.0 and the latest stable Rust release.
+This crate is built against the latest stable release, and its minimum supported rustc version is 1.86.0.
 
-The minimum supported Rust version may increase in a minor release. Each increase is recorded as a breaking change in the changelog.
+The policy is that the minimum Rust version required to use this crate can be increased in minor version updates. For example, if Asyncband 1.0 requires Rust 1.20.0, then Asyncband 1.0.z for all values of z will also require Rust 1.20.0 or newer. However, Asyncband 1.y for y > 0 may require a newer minimum version of Rust.
 
 ## License and Trademarks
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ async fn increment() {
 }
 ```
 
-Public paths stay direct—such as `asyncband::mutex`, `asyncband::pool`, and `asyncband::once::OnceCell`—while Cargo features keep unused implementations out of the build.
+Public modules stay at direct crate-root paths. Related variants are grouped beneath their semantic family—for example, initialization cells under `asyncband::once` and MPMC broadcast under `asyncband::broadcast::mpmc`. Cargo features select compiled APIs; topology and bounded or unbounded policies remain module or constructor choices rather than separate features.
 
 ## Examples
 
@@ -75,10 +75,10 @@ Runnable examples live in the [`examples`](examples) workspace crate. They demon
 |                       | [`Latch`](https://docs.rs/asyncband/*/asyncband/latch/struct.Latch.html)             | `latch`        | Wait until a one-way countdown completes.                                                              |
 |                       | [`WaitGroup`](https://docs.rs/asyncband/*/asyncband/waitgroup/struct.WaitGroup.html) | `waitgroup`    | Wait for a dynamic group of tasks to finish.                                                           |
 |                       | [`Shutdown`](https://docs.rs/asyncband/*/asyncband/shutdown/struct.Shutdown.html)    | `shutdown`     | Coordinate shutdown signals and completion.                                                            |
-| Channels              | [`oneshot`](https://docs.rs/asyncband/*/asyncband/oneshot/)                          | `oneshot`      | Send one value between two tasks.                                                                      |
-|                       | [`mpsc`](https://docs.rs/asyncband/*/asyncband/mpsc/)                                | `mpsc`         | Send each value from multiple producers to one receiver.                                               |
-|                       | [`broadcast`](https://docs.rs/asyncband/*/asyncband/broadcast/)                      | `broadcast`    | Broadcast values from one or more producers and retain them until every active receiver consumes them. |
-|                       | [`watch`](https://docs.rs/asyncband/*/asyncband/watch/)                              | `watch`        | Retain the latest state and coalesce intermediate updates.                                             |
+| Channels              | [`oneshot`](https://docs.rs/asyncband/*/asyncband/oneshot/)                          | `oneshot`      | Send one value from one sender to one receiver.                                                         |
+|                       | [`mpsc`](https://docs.rs/asyncband/*/asyncband/mpsc/)                                | `mpsc`         | Send each value from multiple producers to one receiver through a bounded or unbounded queue.           |
+|                       | [`broadcast::mpmc`](https://docs.rs/asyncband/*/asyncband/broadcast/mpmc/)            | `broadcast`    | Broadcast every value from multiple producers to every active receiver with unbounded retention.        |
+|                       | [`watch`](https://docs.rs/asyncband/*/asyncband/watch/)                              | `watch`        | Publish the latest state to independently tracked receivers and coalesce intermediate updates.          |
 | Resource reuse        | [`pool`](https://docs.rs/asyncband/*/asyncband/pool/)                                | `pool`         | Reuse objects through bounded or unbounded pool variants.                                              |
 | Workload coordination | [`Semaphore`](https://docs.rs/asyncband/*/asyncband/semaphore/struct.Semaphore.html) | `semaphore`    | Control concurrent access with permits.                                                                |
 |                       | [`Group`](https://docs.rs/asyncband/*/asyncband/singleflight/struct.Group.html)      | `singleflight` | Coalesce concurrent calls for the same key.                                                            |
@@ -123,9 +123,9 @@ Asyncband types implement `Send` and `Sync` only when the protected, transferred
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is built against the latest stable release, and its minimum supported rustc version is 1.86.0.
+Asyncband supports rustc 1.86.0 and newer. CI tests both 1.86.0 and the latest stable Rust release.
 
-The policy is that the minimum Rust version required to use this crate can be increased in minor version updates. For example, if Asyncband 1.0 requires Rust 1.20.0, then Asyncband 1.0.z for all values of z will also require Rust 1.20.0 or newer. However, Asyncband 1.y for y > 0 may require a newer minimum version of Rust.
+The minimum supported Rust version may increase in a minor release. Each increase is recorded as a breaking change in the changelog.
 
 ## License and Trademarks
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -61,7 +61,7 @@ After one successful Trusted Publishing release, remove any legacy `CARGO_REGIST
 Start from current `main` and choose `VERSION` according to the changes since the latest crates.io release.
 
 1. Change `version` in `asyncband/Cargo.toml` and refresh `Cargo.lock` with Cargo.
-2. Move the entries under `Unreleased` in `CHANGELOG.md` into a dated `VERSION` section, then restore an empty `Unreleased` section.
+2. Move the entries under `Unreleased` in `CHANGELOG.md` into a dated `VERSION` section, then restore an empty `Unreleased` section. Keep user-impacting sections ordered as breaking changes, new features, bug fixes, and improvements.
 3. Confirm that `LICENSE`, `NOTICE`, and `DISCLAIMER` are correct and that all source files have the required license headers.
 4. Run the normal validation and the semver check:
 

--- a/asyncband/src/lib.rs
+++ b/asyncband/src/lib.rs
@@ -64,10 +64,10 @@
 //! |                       | [`Latch`](latch::Latch)             | `latch`        | Wait until a one-way countdown completes.                                                              |
 //! |                       | [`WaitGroup`](waitgroup::WaitGroup) | `waitgroup`    | Wait for a dynamic group of tasks to finish.                                                           |
 //! |                       | [`Shutdown`](shutdown::Shutdown)    | `shutdown`     | Coordinate shutdown signals and completion.                                                            |
-//! | Channels              | [`oneshot`]                         | `oneshot`      | Send one value between two tasks.                                                                      |
-//! |                       | [`mpsc`]                            | `mpsc`         | Send each value from multiple producers to one receiver.                                               |
-//! |                       | [`broadcast`]                       | `broadcast`    | Broadcast values from one or more producers and retain them until every active receiver consumes them. |
-//! |                       | [`watch`]                           | `watch`        | Retain the latest state and coalesce intermediate updates.                                             |
+//! | Channels              | [`oneshot`]                         | `oneshot`      | Send one value from one sender to one receiver.                                                         |
+//! |                       | [`mpsc`]                            | `mpsc`         | Send each value from multiple producers to one receiver through a bounded or unbounded queue.           |
+//! |                       | [`broadcast::mpmc`]                 | `broadcast`    | Broadcast every value from multiple producers to every active receiver with unbounded retention.        |
+//! |                       | [`watch`]                           | `watch`        | Publish the latest state to independently tracked receivers and coalesce intermediate updates.          |
 //! | Resource reuse        | [`pool`]                            | `pool`         | Reuse objects through bounded or unbounded pool variants.                                              |
 //! | Workload coordination | [`Semaphore`](semaphore::Semaphore) | `semaphore`    | Control concurrent access with permits.                                                                |
 //! |                       | [`Group`](singleflight::Group)      | `singleflight` | Coalesce concurrent calls for the same key.                                                            |

--- a/asyncband/src/lib.rs
+++ b/asyncband/src/lib.rs
@@ -66,7 +66,7 @@
 //! |                       | [`Shutdown`](shutdown::Shutdown)    | `shutdown`     | Coordinate shutdown signals and completion.                                                            |
 //! | Channels              | [`oneshot`]                         | `oneshot`      | Send one value from one sender to one receiver.                                                         |
 //! |                       | [`mpsc`]                            | `mpsc`         | Send each value from multiple producers to one receiver through a bounded or unbounded queue.           |
-//! |                       | [`broadcast::mpmc`]                 | `broadcast`    | Broadcast every value from multiple producers to every active receiver with unbounded retention.        |
+//! |                       | [`broadcast`]                       | `broadcast`    | Broadcast values from one or more producers and retain them until every active receiver consumes them. |
 //! |                       | [`watch`]                           | `watch`        | Publish the latest state to independently tracked receivers and coalesce intermediate updates.          |
 //! | Resource reuse        | [`pool`]                            | `pool`         | Reuse objects through bounded or unbounded pool variants.                                              |
 //! | Workload coordination | [`Semaphore`](semaphore::Semaphore) | `semaphore`    | Control concurrent access with permits.                                                                |


### PR DESCRIPTION
## Summary

- put breaking changes first in the unreleased changelog, order the remaining sections by user impact, and describe the shipped broadcast replacement precisely
- keep the README and crate-level API maps aligned at the Cargo feature-family level while clarifying oneshot, MPSC, and watch delivery semantics
- preserve the changelog section order in the release runbook

Validation: `cargo x lint`, `cargo x check`, `cargo x test`, and `git diff --check`.
