### PR TITLE
chore: harden 0.7 release preparation

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -73,6 +73,17 @@ cargo x semver --release-version "${VERSION}"
 cargo publish --package asyncband --locked --dry-run
 ```
 
+For a semver-major release, including a pre-1.0 minor release such as `0.7.0`, the semver command
+audits with minor compatibility rules so that breaking API changes remain visible. Review every
+reported change against `CHANGELOG.md` and `MIGRATE.md`, then explicitly acknowledge the reviewed
+inventory:
+
+```shell
+cargo x semver --release-version "${VERSION}" --acknowledge-breaking-changes
+```
+
+Do not use `--acknowledge-breaking-changes` for a semver-minor or semver-patch release.
+
 Open and merge a normal pull request. Do not push the version change directly to `main`; the final release is identified by tags, so the release process does not require a direct branch push.
 
 Record the merge commit as `RELEASE_COMMIT`. All candidate artifacts, the final tag, and the crates.io package must come from this exact commit.
@@ -115,13 +126,15 @@ git archive --format=tar --prefix="${SOURCE_DIR}/" "${RC_TAG}" \
 Verify the artifacts before uploading them:
 
 ```shell
-cd dist
-shasum -a 512 --check "${SOURCE_DIR}.tar.gz.sha512"
-gpg --verify "${SOURCE_DIR}.tar.gz.asc" "${SOURCE_DIR}.tar.gz"
-tar --extract --gzip --file "${SOURCE_DIR}.tar.gz"
-cd "${SOURCE_DIR}"
-cargo test --workspace --all-features --locked
-cargo publish --package asyncband --locked --dry-run
+(
+  cd dist
+  shasum -a 512 --check "${SOURCE_DIR}.tar.gz.sha512"
+  gpg --verify "${SOURCE_DIR}.tar.gz.asc" "${SOURCE_DIR}.tar.gz"
+  tar --extract --gzip --file "${SOURCE_DIR}.tar.gz"
+  cd "${SOURCE_DIR}"
+  cargo test --workspace --all-features --locked
+  cargo publish --package asyncband --locked --dry-run
+)
 ```
 
 Also inspect the archive for unexpected binary files, verify `LICENSE`, `NOTICE`, and `DISCLAIMER`, and check that its contents correspond to the RC tag.

--- a/asyncband/src/pool/bounded.rs
+++ b/asyncband/src/pool/bounded.rs
@@ -297,10 +297,35 @@ impl<M: ManageObject> Pool<M> {
     /// objects from the pool that have not been used for more than one minute. The task will
     /// terminate if the pool is dropped.
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
+    /// # use std::convert::Infallible;
+    /// # use std::sync::Arc;
+    /// # use std::time::Duration;
+    /// # use asyncband::pool::ManageObject;
+    /// # use asyncband::pool::ObjectStatus;
+    /// # use asyncband::pool::bounded::Pool;
+    /// # use asyncband::pool::bounded::PoolConfig;
     /// let interval = Duration::from_secs(30);
     /// let max_age = Duration::from_secs(60);
     ///
+    /// # struct Manager;
+    /// # impl ManageObject for Manager {
+    /// #     type Object = u32;
+    /// #     type Error = Infallible;
+    /// #
+    /// #     async fn create(&self) -> Result<Self::Object, Self::Error> {
+    /// #         Ok(0)
+    /// #     }
+    /// #
+    /// #     async fn is_recyclable(
+    /// #         &self,
+    /// #         _object: &mut Self::Object,
+    /// #         _status: &ObjectStatus,
+    /// #     ) -> Result<(), Self::Error> {
+    /// #         Ok(())
+    /// #     }
+    /// # }
+    /// # let pool = Pool::new(PoolConfig::new(16), Manager);
     /// let weak_pool = Arc::downgrade(&pool);
     /// tokio::spawn(async move {
     ///     loop {

--- a/asyncband/src/pool/mod.rs
+++ b/asyncband/src/pool/mod.rs
@@ -113,28 +113,60 @@
 //! deadline for the complete checkout operation. Asyncband therefore returns an ordinary future so
 //! the caller can apply one end-to-end deadline with its chosen timer:
 //!
-//! ```rust,ignore
+//! ```rust,no_run
 //! use std::sync::Arc;
 //! use std::time::Duration;
 //!
+//! use asyncband::pool::ManageObject;
+//! use asyncband::pool::ObjectStatus;
 //! use asyncband::pool::bounded::Object;
 //! use asyncband::pool::bounded::Pool;
+//! # use asyncband::pool::bounded::PoolConfig;
 //!
-//! #[derive(Debug, Clone)]
-//! pub struct ConnectionPool {
+//! # struct Connection;
+//! # #[derive(Debug)]
+//! # struct Error;
+//! # struct ManageConnection;
+//! # impl ManageObject for ManageConnection {
+//! #     type Object = Connection;
+//! #     type Error = Error;
+//! #
+//! #     async fn create(&self) -> Result<Self::Object, Self::Error> {
+//! #         Ok(Connection)
+//! #     }
+//! #
+//! #     async fn is_recyclable(
+//! #         &self,
+//! #         _object: &mut Self::Object,
+//! #         _status: &ObjectStatus,
+//! #     ) -> Result<(), Self::Error> {
+//! #         Ok(())
+//! #     }
+//! # }
+//! # enum AcquireError {
+//! #     Create(Error),
+//! #     Timeout,
+//! # }
+//!
+//! #[derive(Clone)]
+//! struct ConnectionPool {
 //!     pool: Arc<Pool<ManageConnection>>,
 //! }
 //!
 //! impl ConnectionPool {
-//!     pub async fn acquire(&self) -> Result<Object<ManageConnection>, Error> {
+//!     async fn acquire(&self) -> Result<Object<ManageConnection>, AcquireError> {
 //!         const ACQUIRE_TIMEOUT: Duration = Duration::from_secs(60);
 //!
 //!         // Callers can use the timer implementation of their runtime.
-//!         let result = tokio::time::timeout(ACQUIRE_TIMEOUT, self.pool.get()).await;
-//!
-//!         // ... processing the result
+//!         match tokio::time::timeout(ACQUIRE_TIMEOUT, self.pool.get()).await {
+//!             Ok(result) => result.map_err(AcquireError::Create),
+//!             Err(_) => Err(AcquireError::Timeout),
+//!         }
 //!     }
 //! }
+//! # let _pool = ConnectionPool {
+//! #     pool: Pool::new(PoolConfig::new(16), ManageConnection),
+//! # };
 //! ```
 //!
 //! ## Why are general before/after hooks outside the pool?

--- a/asyncband/src/pool/unbounded.rs
+++ b/asyncband/src/pool/unbounded.rs
@@ -400,10 +400,15 @@ impl<T, M: ManageObject<Object = T>> Pool<T, M> {
     /// objects from the pool that have not been used for more than one minute. The task will
     /// terminate if the pool is dropped.
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
+    /// # use std::sync::Arc;
+    /// # use std::time::Duration;
+    /// # use asyncband::pool::unbounded::Pool;
+    /// # use asyncband::pool::unbounded::PoolConfig;
     /// let interval = Duration::from_secs(30);
     /// let max_age = Duration::from_secs(60);
     ///
+    /// # let pool = Pool::<Vec<u8>>::never_manage(PoolConfig::default());
     /// let weak_pool = Arc::downgrade(&pool);
     /// tokio::spawn(async move {
     ///     loop {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -17,6 +17,7 @@
 
 use std::path::Path;
 use std::process::Command as StdCommand;
+use std::process::ExitStatus;
 use std::time::Duration;
 
 use clap::Parser;
@@ -25,6 +26,8 @@ use semver::Version;
 use serde::Deserialize;
 
 const PACKAGE_NAME: &str = "asyncband";
+// cargo-semver-checks reserves exit code 100 for completed checks that found deny-level violations.
+const SEMVER_VIOLATIONS_EXIT_CODE: i32 = 100;
 
 #[derive(Parser)]
 struct Command {
@@ -136,6 +139,12 @@ fn asyncband_features() -> Vec<String> {
 struct CommandSemver {
     #[arg(long, value_name = "VERSION", help = "Version that will be released.")]
     release_version: Version,
+
+    #[arg(
+        long,
+        help = "Accept reviewed breaking API changes for a semver-major release."
+    )]
+    acknowledge_breaking_changes: bool,
 }
 
 impl CommandSemver {
@@ -148,12 +157,44 @@ impl CommandSemver {
         };
 
         let release_type = classify_release_type(&baseline_version, &self.release_version);
+        assert!(
+            release_type == SemverReleaseType::Major || !self.acknowledge_breaking_changes,
+            "--acknowledge-breaking-changes is only valid for a semver-major release"
+        );
+
+        let audit_release_type = release_type.audit_release_type();
         println!(
             "Checking release {} against {PACKAGE_NAME}@{baseline_version} as a {} release.",
             self.release_version,
             release_type.as_str()
         );
-        run_command(make_semver_check_cmd(&baseline_version, release_type));
+        if audit_release_type != release_type {
+            println!(
+                "Auditing with minor compatibility rules so breaking API changes remain visible."
+            );
+        }
+
+        let status = command_status(make_semver_check_cmd(&baseline_version, audit_release_type));
+        if status.success() {
+            return;
+        }
+
+        if release_type == SemverReleaseType::Major
+            && status.code() == Some(SEMVER_VIOLATIONS_EXIT_CODE)
+        {
+            assert!(
+                self.acknowledge_breaking_changes,
+                "breaking API changes were reported; document and review them, then rerun with \
+                 --acknowledge-breaking-changes"
+            );
+            println!(
+                "The breaking API changes reported above are acknowledged for release {}.",
+                self.release_version
+            );
+            return;
+        }
+
+        panic!("command failed: {status}");
     }
 }
 
@@ -190,6 +231,13 @@ impl SemverReleaseType {
             Self::Patch => "patch",
         }
     }
+
+    fn audit_release_type(self) -> Self {
+        match self {
+            Self::Major => Self::Minor,
+            release_type => release_type,
+        }
+    }
 }
 
 fn find_command(cmd: &str) -> StdCommand {
@@ -213,10 +261,14 @@ fn ensure_installed(bin: &str, crate_name: &str) {
     }
 }
 
-fn run_command(mut cmd: StdCommand) {
-    println!("{cmd:?}");
-    let status = cmd.status().expect("failed to execute process");
+fn run_command(cmd: StdCommand) {
+    let status = command_status(cmd);
     assert!(status.success(), "command failed: {status}");
+}
+
+fn command_status(mut cmd: StdCommand) -> ExitStatus {
+    println!("{cmd:?}");
+    cmd.status().expect("failed to execute process")
 }
 
 fn find_latest_release() -> Option<Version> {
@@ -451,5 +503,21 @@ mod tests {
                 expected
             );
         }
+    }
+
+    #[test]
+    fn audit_major_releases_with_minor_compatibility_rules() {
+        assert_eq!(
+            SemverReleaseType::Major.audit_release_type(),
+            SemverReleaseType::Minor
+        );
+        assert_eq!(
+            SemverReleaseType::Minor.audit_release_type(),
+            SemverReleaseType::Minor
+        );
+        assert_eq!(
+            SemverReleaseType::Patch.audit_release_type(),
+            SemverReleaseType::Patch
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Audit semver-major releases with minor compatibility rules so breaking API changes remain visible, and require explicit acknowledgement before accepting those violations.
- Turn the three ignored pool examples into compiling doctests with complete setup.
- Document the breaking-change review flow and keep source-archive verification inside a subshell so later release commands run from the repository root.
- Validate with `cargo x lint`, `cargo x check`, `cargo x test --no-capture`, Rust 1.86.0 tests, both semver acknowledgement paths, and a Cargo package dry-run.
- Advances #227.
