### PR TITLE
test: add targeted Miri coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,31 @@ jobs:
         run: cargo x test --no-capture
         shell: bash
 
+  miri:
+    name: Run Miri tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      RUSTUP_TOOLCHAIN: nightly
+      MIRIFLAGS: >-
+        -Zmiri-strict-provenance
+        -Zmiri-symbolic-alignment-check
+        -Zmiri-many-seeds=0..4
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install nightly toolchain
+        run: >-
+          rustup toolchain install nightly
+          --profile minimal
+          --component miri
+          --allow-downgrade
+          --no-self-update
+      - uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - name: Set up Miri
+        run: cargo +nightly miri setup
+      - name: Run Miri tests
+        run: cargo x miri
+
   benchmark:
     name: Run benchmarks
     runs-on: ubuntu-24.04
@@ -110,6 +135,7 @@ jobs:
     needs:
       - benchmark
       - check
+      - miri
       - test
     steps:
       - name: Guardian
@@ -117,6 +143,7 @@ jobs:
           if [[ ! ( \
                  "${{ needs.benchmark.result }}" == "success" \
               && "${{ needs.check.result }}" == "success" \
+              && "${{ needs.miri.result }}" == "success" \
               && "${{ needs.test.result }}" == "success" \
               ) ]]; then
             echo "Required jobs haven't been completed successfully."

--- a/asyncband/src/internal/semaphore.rs
+++ b/asyncband/src/internal/semaphore.rs
@@ -451,3 +451,46 @@ fn acquired_or_enqueue(
         return false;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+    use std::task::Wake;
+
+    use super::*;
+
+    struct WakeCounter(AtomicUsize);
+
+    impl Wake for WakeCounter {
+        fn wake(self: Arc<Self>) {
+            self.0.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    #[test]
+    fn release_drains_more_than_one_wake_batch() {
+        const WAITER_COUNT: usize = WAKE_BATCH_SIZE + 3;
+
+        let semaphore = Semaphore::new(0);
+        let counter = Arc::new(WakeCounter(AtomicUsize::new(0)));
+        let waker = Waker::from(counter.clone());
+        let mut acquires = (0..WAITER_COUNT)
+            .map(|_| semaphore.poll_acquire(1))
+            .collect::<Vec<_>>();
+
+        for acquire in &mut acquires {
+            assert!(acquire.poll_once(&waker).is_pending());
+        }
+        assert_eq!(semaphore.num_waiter_nodes(), WAITER_COUNT);
+
+        semaphore.release(WAITER_COUNT);
+        assert_eq!(counter.0.load(Ordering::Relaxed), WAITER_COUNT);
+
+        for acquire in &mut acquires {
+            assert!(acquire.poll_once(&waker).is_ready());
+        }
+        assert_eq!(semaphore.num_waiter_nodes(), 0);
+    }
+}

--- a/asyncband/src/internal/waitset.rs
+++ b/asyncband/src/internal/waitset.rs
@@ -214,25 +214,24 @@ mod tests {
     #[test]
     fn stale_token_does_not_alias_a_reused_slot() {
         let mut waiters = WaitSet::new();
-        let first_waker = Waker::from(Arc::new(TrackWake(AtomicUsize::new(0))));
-        let second_waker = Waker::from(Arc::new(TrackWake(AtomicUsize::new(0))));
-        let mut first = None;
-        let mut second = None;
+        let first_task = Arc::new(TrackWake(AtomicUsize::new(0)));
+        let first_waker = Waker::from(first_task.clone());
+        let second_task = Arc::new(TrackWake(AtomicUsize::new(0)));
+        let second_waker = Waker::from(second_task.clone());
+        let mut first_token = None;
+        let mut second_token = None;
 
-        register(&mut waiters, &mut first, &first_waker);
+        register(&mut waiters, &mut first_token, &first_waker);
         assert_eq!(waiters.take_wakers().count(), 1);
 
-        register(&mut waiters, &mut second, &second_waker);
-        register(&mut waiters, &mut first, &first_waker);
+        register(&mut waiters, &mut second_token, &second_waker);
+        register(&mut waiters, &mut first_token, &first_waker);
 
         let registered = waiters.take_wakers().collect::<Vec<_>>();
         assert_eq!(registered.len(), 2);
-        assert!(registered.iter().any(|waker| waker.will_wake(&first_waker)));
-        assert!(
-            registered
-                .iter()
-                .any(|waker| waker.will_wake(&second_waker))
-        );
+        wake_all(registered.into_iter());
+        assert_eq!(first_task.0.load(Ordering::Relaxed), 1);
+        assert_eq!(second_task.0.load(Ordering::Relaxed), 1);
     }
 
     #[test]

--- a/asyncband/src/once/once_map/tests.rs
+++ b/asyncband/src/once/once_map/tests.rs
@@ -15,9 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::cell::Cell;
+use std::future::poll_fn;
 use std::hash::BuildHasherDefault;
 use std::hash::Hasher;
+use std::panic::AssertUnwindSafe;
+use std::panic::catch_unwind;
+use std::pin::pin;
 use std::sync::Arc;
+use std::task::Poll;
 
 use super::Lookup;
 use super::OnceMap;
@@ -36,53 +42,41 @@ impl Hasher for ConstantHasher {
     fn write(&mut self, _bytes: &[u8]) {}
 }
 
-#[tokio::test]
-async fn failed_compute_removes_empty_entry() {
+#[test]
+fn failed_compute_removes_empty_entry() {
     let map = OnceMap::new();
 
-    let result: Result<i32, &str> = map.try_compute("key", async || Err("fail")).await;
+    let mut compute = pin!(map.try_compute("key", async || Err::<i32, &str>("fail")));
 
-    assert_eq!(result, Err("fail"));
+    assert_eq!(poll_once(compute.as_mut()), Poll::Ready(Err("fail")));
     assert_eq!(map.len(), 0);
 }
 
-#[tokio::test]
-async fn panicked_compute_removes_empty_entry() {
-    let map = Arc::new(OnceMap::<&str, i32>::new());
+#[test]
+fn panicked_compute_removes_empty_entry() {
+    let map = OnceMap::<&str, i32>::new();
 
-    let map_clone = map.clone();
-    let task = tokio::spawn(async move {
-        map_clone
-            .compute("key", async || {
-                panic!("oops");
-            })
-            .await
-    });
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        let mut compute = pin!(map.compute("key", async || {
+            panic!("oops");
+        }));
+        let _ = poll_once(compute.as_mut());
+    }));
 
-    assert!(task.await.unwrap_err().is_panic());
+    assert!(result.is_err());
     assert_eq!(map.len(), 0);
 }
 
-#[tokio::test]
-async fn cancelled_compute_removes_empty_entry() {
-    let map = Arc::new(OnceMap::<&str, i32>::new());
-    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+#[test]
+fn cancelled_compute_removes_empty_entry() {
+    let map = OnceMap::<&str, i32>::new();
 
-    let map_clone = map.clone();
-    let task = tokio::spawn(async move {
-        map_clone
-            .compute("key", async move || {
-                started_tx.send(()).unwrap();
-                std::future::pending().await
-            })
-            .await
-    });
+    {
+        let mut compute = pin!(map.compute("key", async || std::future::pending::<i32>().await));
+        assert!(poll_once(compute.as_mut()).is_pending());
+        assert_eq!(map.len(), 1);
+    }
 
-    started_rx.await.unwrap();
-    assert_eq!(map.len(), 1);
-
-    task.abort();
-    assert!(task.await.unwrap_err().is_cancelled());
     assert_eq!(map.len(), 0);
 }
 
@@ -102,27 +96,33 @@ fn pending_computation_does_not_block_another_key() {
     assert_eq!(map.len(), 1);
 }
 
-#[tokio::test]
-async fn failed_compute_preserves_entry_for_waiter_retry() {
+#[test]
+fn failed_compute_preserves_entry_for_waiter_retry() {
     let map = OnceMap::new();
-    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+    let released = Cell::new(false);
 
-    let first = map.try_compute("key", async move || {
-        release_rx.await.unwrap();
+    let first = map.try_compute("key", async || {
+        poll_fn(|_| {
+            released
+                .get()
+                .then_some(())
+                .map_or(Poll::Pending, Poll::Ready)
+        })
+        .await;
         Err::<i32, &str>("fail")
     });
-    tokio::pin!(first);
+    let mut first = pin!(first);
     assert!(poll_once(first.as_mut()).is_pending());
 
     let retry = map.try_compute("key", async || Ok::<i32, &str>(1));
-    tokio::pin!(retry);
+    let mut retry = pin!(retry);
     assert!(poll_once(retry.as_mut()).is_pending());
 
-    release_tx.send(()).unwrap();
-    assert_eq!(first.await, Err("fail"));
+    released.set(true);
+    assert_eq!(poll_once(first.as_mut()), Poll::Ready(Err("fail")));
 
     assert_eq!(map.len(), 1);
-    assert_eq!(retry.await, Ok(1));
+    assert_eq!(poll_once(retry.as_mut()), Poll::Ready(Ok(1)));
     assert_eq!(map.get("key"), Some(1));
 }
 

--- a/asyncband/src/singleflight/tests.rs
+++ b/asyncband/src/singleflight/tests.rs
@@ -15,7 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::sync::Arc;
+use std::cell::Cell;
+use std::future::poll_fn;
+use std::panic::AssertUnwindSafe;
+use std::panic::catch_unwind;
+use std::pin::pin;
+use std::task::Poll;
 
 use super::Group;
 use crate::test_support::poll_once;
@@ -26,85 +31,75 @@ fn entry_count<K, V, S>(group: &Group<K, V, S>) -> usize {
     group.entries.lock().len()
 }
 
-#[tokio::test]
-async fn panicked_work_removes_empty_entry() {
-    let group = Arc::new(Group::<&str, String>::new());
+#[test]
+fn panicked_work_removes_empty_entry() {
+    let group = Group::<&str, String>::new();
 
-    let group_clone = group.clone();
-    let task = tokio::spawn(async move {
-        group_clone
-            .work("key", || async {
-                panic!("oops");
-            })
-            .await
-    });
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        let mut work = pin!(group.work("key", || async {
+            panic!("oops");
+        }));
+        let _ = poll_once(work.as_mut());
+    }));
 
-    assert!(task.await.unwrap_err().is_panic());
+    assert!(result.is_err());
     assert_eq!(entry_count(&group), 0);
 
-    let result = group.work("key", || async { "success".to_owned() }).await;
-    assert_eq!(result, "success");
+    let mut retry = pin!(group.work("key", || async { "success".to_owned() }));
+    assert_eq!(poll_once(retry.as_mut()), Poll::Ready("success".to_owned()));
 }
 
-#[tokio::test]
-async fn cancelled_work_removes_empty_entry() {
-    let group = Arc::new(Group::<&str, &str>::new());
-    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+#[test]
+fn cancelled_work_removes_empty_entry() {
+    let group = Group::<&str, &str>::new();
 
-    let group_clone = group.clone();
-    let task = tokio::spawn(async move {
-        group_clone
-            .work("key", || async move {
-                started_tx.send(()).unwrap();
-                std::future::pending().await
-            })
-            .await
-    });
+    {
+        let mut work = pin!(group.work("key", || async { std::future::pending::<&str>().await }));
+        assert!(poll_once(work.as_mut()).is_pending());
+        assert_eq!(entry_count(&group), 1);
+    }
 
-    started_rx.await.unwrap();
-    assert_eq!(entry_count(&group), 1);
-
-    task.abort();
-    assert!(task.await.unwrap_err().is_cancelled());
     assert_eq!(entry_count(&group), 0);
 }
 
-#[tokio::test]
-async fn failed_try_work_removes_empty_entry() {
+#[test]
+fn failed_try_work_removes_empty_entry() {
     let group = Group::new();
 
-    let result = group
-        .try_work("key", || async { Err::<&str, &str>("error") })
-        .await;
-    assert_eq!(result, Err("error"));
+    let mut work = pin!(group.try_work("key", || async { Err::<&str, &str>("error") }));
+    assert_eq!(poll_once(work.as_mut()), Poll::Ready(Err("error")));
     assert_eq!(entry_count(&group), 0);
 
-    let retry = group
-        .try_work("key", || async { Ok::<&str, ()>("success") })
-        .await;
-    assert_eq!(retry, Ok("success"));
+    let mut retry = pin!(group.try_work("key", || async { Ok::<&str, ()>("success") }));
+    assert_eq!(poll_once(retry.as_mut()), Poll::Ready(Ok("success")));
 }
 
-#[tokio::test]
-async fn failed_try_work_preserves_entry_for_waiter_retry() {
+#[test]
+fn failed_try_work_preserves_entry_for_waiter_retry() {
     let group = Group::new();
-    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+    let released = Cell::new(false);
 
-    let first = group.try_work("key", || async move {
-        release_rx.await.unwrap();
+    let first = group.try_work("key", || async {
+        poll_fn(|_| {
+            released
+                .get()
+                .then_some(())
+                .map_or(Poll::Pending, Poll::Ready)
+        })
+        .await;
         Err::<&str, &str>("fail")
     });
-    tokio::pin!(first);
+    let mut first = pin!(first);
     assert!(poll_once(first.as_mut()).is_pending());
 
     let retry = group.try_work("key", || async { Ok::<&str, &str>("success") });
-    tokio::pin!(retry);
+    let mut retry = pin!(retry);
     assert!(poll_once(retry.as_mut()).is_pending());
 
-    release_tx.send(()).unwrap();
-    assert_eq!(first.await, Err("fail"));
+    released.set(true);
+    assert_eq!(poll_once(first.as_mut()), Poll::Ready(Err("fail")));
 
     assert_eq!(entry_count(&group), 1);
-    assert_eq!(retry.await, Ok("success"));
+    assert_eq!(poll_once(retry.as_mut()), Poll::Ready(Ok("success")));
     assert_eq!(entry_count(&group), 0);
 }

--- a/tests-integration/tests/unsafe_paths_test.rs
+++ b/tests-integration/tests/unsafe_paths_test.rs
@@ -1,0 +1,172 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::cell::Cell;
+use std::future::Future;
+use std::marker::PhantomPinned;
+use std::pin::Pin;
+use std::pin::pin;
+use std::ptr;
+use std::sync::Arc;
+use std::task::Context;
+use std::task::Poll;
+use std::task::Waker;
+
+use asyncband::mutex::MappedMutexGuard;
+use asyncband::mutex::Mutex;
+use asyncband::mutex::MutexGuard;
+use asyncband::mutex::OwnedMappedMutexGuard;
+use asyncband::mutex::OwnedMutexGuard;
+use asyncband::once::LazyCell;
+use asyncband::rwlock::MappedRwLockReadGuard;
+use asyncband::rwlock::MappedRwLockWriteGuard;
+use asyncband::rwlock::OwnedMappedRwLockReadGuard;
+use asyncband::rwlock::OwnedMappedRwLockWriteGuard;
+use asyncband::rwlock::OwnedRwLockReadGuard;
+use asyncband::rwlock::OwnedRwLockWriteGuard;
+use asyncband::rwlock::RwLock;
+use asyncband::rwlock::RwLockReadGuard;
+use asyncband::rwlock::RwLockWriteGuard;
+
+fn poll_once<F: Future>(future: Pin<&mut F>) -> Poll<F::Output> {
+    future.poll(&mut Context::from_waker(Waker::noop()))
+}
+
+#[test]
+fn mapped_mutex_guards_preserve_lock_ownership() {
+    let mutex = Mutex::new((vec![1, 2], 3));
+    let guard = mutex.try_lock().unwrap();
+    let mapped = MutexGuard::map(guard, |value| &mut value.0);
+    let mut mapped = MappedMutexGuard::map(mapped, |values| &mut values[1]);
+    assert!(mutex.try_lock().is_none());
+    *mapped = 4;
+    drop(mapped);
+    assert_eq!(mutex.into_inner(), (vec![1, 4], 3));
+
+    let mutex = Arc::new(Mutex::new(Some(vec![5, 6])));
+    let weak = Arc::downgrade(&mutex);
+    let guard = mutex.clone().try_lock_owned().unwrap();
+    let mapped = OwnedMutexGuard::filter_map(guard, Option::as_mut).unwrap();
+    let mut mapped = OwnedMappedMutexGuard::map(mapped, |values| &mut values[0]);
+    assert!(mutex.try_lock().is_none());
+    *mapped = 7;
+    drop(mapped);
+    let guard = mutex.try_lock().unwrap();
+    assert_eq!(guard.as_deref(), Some([7, 6].as_slice()));
+    drop(guard);
+
+    drop(mutex);
+    assert!(weak.upgrade().is_none());
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct Data {
+    values: Vec<i32>,
+    label: String,
+}
+
+#[test]
+fn mapped_rwlock_guards_preserve_lock_ownership() {
+    let lock = RwLock::new(Data {
+        values: vec![1, 2],
+        label: "borrowed".to_owned(),
+    });
+    let write = lock.try_write().unwrap();
+    let mapped = RwLockWriteGuard::map(write, |data| &mut data.values);
+    let mut mapped = MappedRwLockWriteGuard::map(mapped, |values| &mut values[1]);
+    *mapped = 3;
+    let mapped = mapped.downgrade();
+    assert_eq!(*mapped, 3);
+    assert!(lock.try_write().is_none());
+    drop(mapped);
+
+    let read = lock.try_read().unwrap();
+    let mapped = RwLockReadGuard::map(read, |data| &data.label);
+    let mapped =
+        MappedRwLockReadGuard::filter_map(mapped, |label| label.strip_prefix("bor")).unwrap();
+    assert_eq!(&*mapped, "rowed");
+    drop(mapped);
+
+    let lock = Arc::new(RwLock::new(Data {
+        values: vec![4, 5],
+        label: "owned".to_owned(),
+    }));
+    let weak = Arc::downgrade(&lock);
+    let write = lock.clone().try_write_owned().unwrap();
+    let mapped = OwnedRwLockWriteGuard::map(write, |data| &mut data.values);
+    let mut mapped =
+        OwnedMappedRwLockWriteGuard::filter_map(mapped, |values| values.first_mut()).unwrap();
+    *mapped = 6;
+    let mapped = mapped.downgrade();
+    assert_eq!(*mapped, 6);
+    drop(mapped);
+
+    let read = lock.clone().try_read_owned().unwrap();
+    let mapped = OwnedRwLockReadGuard::map(read, |data| &data.label);
+    let mapped =
+        OwnedMappedRwLockReadGuard::filter_map(mapped, |label| label.strip_suffix("ed")).unwrap();
+    assert_eq!(&*mapped, "own");
+    drop(mapped);
+
+    drop(lock);
+    assert!(weak.upgrade().is_none());
+}
+
+struct AddressSensitiveFuture {
+    address: Cell<*const Self>,
+    _pin: PhantomPinned,
+}
+
+impl AddressSensitiveFuture {
+    fn new() -> Self {
+        Self {
+            address: Cell::new(ptr::null()),
+            _pin: PhantomPinned,
+        }
+    }
+}
+
+impl Future for AddressSensitiveFuture {
+    type Output = i32;
+
+    fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.as_ref().get_ref();
+        let current = ptr::from_ref(this);
+        let first = this.address.get();
+        if first.is_null() {
+            this.address.set(current);
+            Poll::Pending
+        } else {
+            assert!(ptr::eq(first, current));
+            Poll::Ready(42)
+        }
+    }
+}
+
+#[test]
+fn lazy_cell_resumes_a_pinned_attempt_in_place() {
+    let lazy = LazyCell::from_future(AddressSensitiveFuture::new());
+    let lazy = pin!(lazy);
+
+    {
+        let mut force = pin!(LazyCell::force_pin(lazy.as_ref()));
+        assert!(poll_once(force.as_mut()).is_pending());
+    }
+
+    let mut force = pin!(LazyCell::force_pin(lazy.as_ref()));
+    assert_eq!(poll_once(force.as_mut()), Poll::Ready(&42));
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -42,6 +42,7 @@ impl Command {
             SubCommand::Build(cmd) => cmd.run(),
             SubCommand::Check(cmd) => cmd.run(),
             SubCommand::Lint(cmd) => cmd.run(),
+            SubCommand::Miri(cmd) => cmd.run(),
             SubCommand::Semver(cmd) => cmd.run(),
             SubCommand::Test(cmd) => cmd.run(),
         }
@@ -58,6 +59,8 @@ enum SubCommand {
     Check(CommandCheck),
     #[clap(about = "Run workspace quality checks.")]
     Lint(CommandLint),
+    #[clap(about = "Check memory safety with Miri.")]
+    Miri(CommandMiri),
     #[clap(about = "Verify API compatibility for a planned release.")]
     Semver(CommandSemver),
     #[clap(about = "Run unit tests.")]
@@ -97,6 +100,23 @@ impl CommandCheck {
             run_command(make_check_cmd(feature));
         }
         run_command(make_check_cmd(&features));
+    }
+}
+
+#[derive(Parser)]
+struct CommandMiri;
+
+impl CommandMiri {
+    fn run(self) {
+        run_command(make_miri_cmd(PACKAGE_NAME, &["--lib", "--all-features"]));
+        run_command(make_miri_cmd(
+            "tests-integration",
+            &["--test", "oneshot_test"],
+        ));
+        run_command(make_miri_cmd(
+            "tests-integration",
+            &["--test", "unsafe_paths_test"],
+        ));
     }
 }
 
@@ -384,6 +404,13 @@ fn make_check_cmd(features: &[String]) -> StdCommand {
     for feature in features {
         cmd.args(["--features", feature]);
     }
+    cmd
+}
+
+fn make_miri_cmd(package: &str, target: &[&str]) -> StdCommand {
+    let mut cmd = find_command("cargo");
+    cmd.args(["+nightly", "miri", "test", "--package", package]);
+    cmd.args(target);
     cmd
 }
 


### PR DESCRIPTION
## Summary

- make the `OnceMap` and `singleflight` cleanup tests runtime-independent by polling their futures directly
- replace a `Waker` identity assertion with observable wake behavior and cover the semaphore wake-batch boundary
- add focused coverage for mapped guards and pinned `LazyCell` initialization
- add `cargo x miri` and a required CI job with strict provenance, symbolic alignment checks, and four Miri seeds

## Design Notes

Running the complete Tokio-backed integration suite under Miri reaches unsupported runtime system calls and would spend most of the job rechecking safe orchestration code. The targeted suite instead runs all 43 library tests, all 19 public oneshot state-machine tests, and three focused mapped-pointer/Pin tests. It completed locally in about 46 seconds across four seeds.

## Validation

- `cargo x check`
- `cargo x test`
- `cargo x lint`
- `MIRIFLAGS='-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-many-seeds=0..4' cargo x miri`
