### PR TITLE
refactor(completion): make Abandoned opaque

### DIFF
--- a/asyncband/src/completion/mod.rs
+++ b/asyncband/src/completion/mod.rs
@@ -97,7 +97,7 @@ enum Status {
 
 /// The error returned by [`Completion::wait`] when the completer was dropped without a value.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Abandoned;
+pub struct Abandoned(());
 
 impl fmt::Display for Abandoned {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -274,7 +274,7 @@ impl<'a, T> Future for Wait<'a, T> {
                     }
                     Status::Abandoned => {
                         let retired = state.waiters.unregister(&mut this.token);
-                        (Poll::Ready(Err(Abandoned)), retired)
+                        (Poll::Ready(Err(Abandoned(()))), retired)
                     }
                 }
             };

--- a/tests-integration/tests/completion_test.rs
+++ b/tests-integration/tests/completion_test.rs
@@ -145,11 +145,8 @@ fn dropping_the_completer_abandons_every_observer() {
     let second = first.clone();
     drop(completer);
 
-    assert_eq!(pollster::block_on(first.wait()), Err(completion::Abandoned));
-    assert_eq!(
-        pollster::block_on(second.wait()),
-        Err(completion::Abandoned)
-    );
+    assert!(pollster::block_on(first.wait()).is_err());
+    assert!(pollster::block_on(second.wait()).is_err());
 }
 
 #[test]
@@ -198,14 +195,14 @@ fn abandonment_wakes_all_registered_waits() {
 
     assert_eq!(first_tracker.0.load(Ordering::Relaxed), 1);
     assert_eq!(second_tracker.0.load(Ordering::Relaxed), 1);
-    assert_eq!(
+    assert!(matches!(
         poll_with(first_wait.as_mut(), &first_waker),
-        Poll::Ready(Err(completion::Abandoned))
-    );
-    assert_eq!(
+        Poll::Ready(Err(_))
+    ));
+    assert!(matches!(
         poll_with(second_wait.as_mut(), &second_waker),
-        Poll::Ready(Err(completion::Abandoned))
-    );
+        Poll::Ready(Err(_))
+    ));
 }
 
 #[test]
@@ -219,10 +216,7 @@ fn payload_errors_remain_distinct_from_abandonment() {
 
     let (completer, completion) = completion::new::<Result<u8, &'static str>>();
     drop(completer);
-    assert_eq!(
-        pollster::block_on(completion.wait()),
-        Err(completion::Abandoned)
-    );
+    assert!(pollster::block_on(completion.wait()).is_err());
 }
 
 #[test]
@@ -281,10 +275,7 @@ fn cancellation_and_completer_drop_have_clean_orderings() {
     assert_eq!(Arc::strong_count(&tracker), baseline);
     drop(completer);
     assert_eq!(tracker.0.load(Ordering::Relaxed), 0);
-    assert_eq!(
-        pollster::block_on(completion.wait()),
-        Err(completion::Abandoned)
-    );
+    assert!(pollster::block_on(completion.wait()).is_err());
 
     let (completer, completion) = completion::new::<usize>();
     let tracker = Arc::new(TrackWake(AtomicUsize::new(0)));
@@ -298,10 +289,7 @@ fn cancellation_and_completer_drop_have_clean_orderings() {
     assert_eq!(Arc::strong_count(&tracker), baseline);
     drop(wait);
     assert_eq!(Arc::strong_count(&tracker), baseline);
-    assert_eq!(
-        pollster::block_on(completion.wait()),
-        Err(completion::Abandoned)
-    );
+    assert!(pollster::block_on(completion.wait()).is_err());
 }
 
 #[test]
@@ -349,19 +337,16 @@ fn wake_callbacks_run_outside_the_completion_lock() {
             let callback_completion = completion.clone();
             let waker = Waker::from(Arc::new(WakeCallback(Mutex::new(Some(Box::new(
                 move || {
-                    assert_eq!(
-                        pollster::block_on(callback_completion.wait()),
-                        Err(completion::Abandoned)
-                    );
+                    assert!(pollster::block_on(callback_completion.wait()).is_err());
                 },
             ))))));
             let mut wait = Box::pin(completion.wait());
             assert!(poll_with(wait.as_mut(), &waker).is_pending());
             drop(completer);
-            assert_eq!(
+            assert!(matches!(
                 poll_with(wait.as_mut(), &waker),
-                Poll::Ready(Err(completion::Abandoned))
-            );
+                Poll::Ready(Err(_))
+            ));
         },
     );
 }
@@ -383,10 +368,10 @@ fn replaced_wakers_are_dropped_outside_the_completion_lock() {
             let replacement = Waker::from(tracker.clone());
             assert!(poll_with(wait.as_mut(), &replacement).is_pending());
             assert_eq!(tracker.0.load(Ordering::Relaxed), 1);
-            assert_eq!(
+            assert!(matches!(
                 poll_with(wait.as_mut(), &replacement),
-                Poll::Ready(Err(completion::Abandoned))
-            );
+                Poll::Ready(Err(_))
+            ));
         },
     );
 }
@@ -404,10 +389,7 @@ fn cancelled_wakers_are_dropped_outside_the_completion_lock() {
             assert!(poll_with(wait.as_mut(), &waker).is_pending());
             drop(waker);
             drop(wait);
-            assert_eq!(
-                pollster::block_on(completion.wait()),
-                Err(completion::Abandoned)
-            );
+            assert!(pollster::block_on(completion.wait()).is_err());
         },
     );
 }

--- a/tests-integration/tests/waitset_reentrancy_test.rs
+++ b/tests-integration/tests/waitset_reentrancy_test.rs
@@ -104,10 +104,10 @@ fn completion_clones_wakers_outside_its_state_lock() {
             let waker = waker_with_clone_callback(move || drop(completer));
             let mut wait = Box::pin(completion.wait());
 
-            assert_eq!(
+            assert!(matches!(
                 poll_with(wait.as_mut(), &waker),
-                Poll::Ready(Err(completion::Abandoned))
-            );
+                Poll::Ready(Err(_))
+            ));
         },
     );
 }


### PR DESCRIPTION
## Summary

- give `completion::Abandoned` a private unit field, following the existing `PoolIsEmpty(())` pattern, so downstream code cannot directly construct or destructure it
- update integration tests to verify abandonment without constructing the error
- preserve its zero-sized layout, `Copy` semantics, and completion behavior

Follow-up to #240.