### PR TITLE
fix: harden panic recovery before 0.7.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,13 @@ Declare restricted visibility at the module boundary and use `pub` for items in 
 
 Keep each Markdown prose paragraph and list item on one source line.
 
+## Changelog
+
+- Update `CHANGELOG.md` for significant user-visible changes by comparing the final behavior with the latest release tag, not by recording the sequence of commits in the current development cycle.
+- Before adding a bug-fix entry, verify from the latest release tag that the faulty behavior was shipped. If the affected API or behavior is itself unreleased, describe only its final contract in the relevant feature entry and omit the development-only correction.
+- Include public API migrations, new capabilities, correctness or compatibility changes, and meaningful performance improvements. Exclude tests, internal refactors, documentation, CI, tooling, dependency maintenance, discarded intermediate APIs, and implementation history unless they change supported or observable behavior relative to the latest release.
+- Write each entry from the user's perspective as one coherent observable change, including required migration guidance for breaking changes.
+
 ## Pull Requests
 
 Format pull request titles according to `.github/semantic.yml` and keep the description concise. Use a `Summary` section for routine changes and add `Design Notes` only when the design needs explanation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ All notable changes to this project will be documented in this file.
 
 * Reject semaphore permit merges whose combined count exceeds `usize::MAX` instead of wrapping and losing permits.
 * Release cancelled wait registrations promptly and reclaim fulfilled `Semaphore::reduce_permits` debt nodes.
-* Preserve fan-out notifications when one registered waker panics.
+* Preserve fan-out notifications, including semaphore permit grants, when one registered waker panics.
+* Leave a watch update unseen when cloning its value panics so the receiver can retry.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,6 @@ All notable changes to this project will be documented in this file.
 * Reject semaphore permit merges whose combined count exceeds `usize::MAX` instead of wrapping and losing permits.
 * Release cancelled wait registrations promptly and reclaim fulfilled `Semaphore::reduce_permits` debt nodes.
 * Preserve fan-out notifications, including semaphore permit grants, when one registered waker panics.
-* Leave a watch update unseen when cloning its value panics so the receiver can retry.
 
 ### Improvements
 

--- a/asyncband/src/internal/mod.rs
+++ b/asyncband/src/internal/mod.rs
@@ -94,12 +94,16 @@ pub(crate) mod waitlist;
     feature = "event",
     feature = "completion",
     feature = "latch",
+    feature = "mpsc",
+    feature = "mutex",
     feature = "once",
+    feature = "rwlock",
+    feature = "semaphore",
     feature = "waitgroup",
     feature = "watch",
 ))]
 // `barrier` constructs a wait set with `with_capacity`, while completion and countdown-based
-// primitives use `new`; `condvar` and `event` use only the free `wake_all` helper. One constructor
-// is therefore unused in every single-primitive build.
+// primitives use `new`; `condvar`, `event`, and semaphore-backed primitives use only the free
+// `wake_all` helper. One constructor is therefore unused in every single-primitive build.
 #[allow(dead_code)]
 pub(crate) mod waitset;

--- a/asyncband/src/internal/semaphore.rs
+++ b/asyncband/src/internal/semaphore.rs
@@ -29,6 +29,7 @@ use std::task::Waker;
 use crate::internal::mutex::Mutex;
 use crate::internal::waitlist::WaitList;
 use crate::internal::waitlist::WaiterId;
+use crate::internal::waitset::wake_all;
 
 /// The internal semaphore that provides low-level async primitives.
 #[derive(Debug)]
@@ -77,12 +78,16 @@ impl WakeBatch {
     }
 
     fn wake_all(&mut self) {
-        while self.start < self.end {
+        wake_all(std::iter::from_fn(|| {
+            if self.start == self.end {
+                return None;
+            }
+
             let index = self.start;
             self.start += 1;
             // SAFETY: `index` was within the initialized range before advancing `start`.
-            unsafe { self.wakers[index].assume_init_read() }.wake();
-        }
+            Some(unsafe { self.wakers[index].assume_init_read() })
+        }));
         self.start = 0;
         self.end = 0;
     }
@@ -221,9 +226,7 @@ impl Semaphore {
             }
         }
         drop(waiters);
-        for w in wakers.drain(..) {
-            w.wake();
-        }
+        wake_all(wakers.into_iter());
     }
 
     fn insert_permits_with_lock(

--- a/asyncband/src/semaphore/mod.rs
+++ b/asyncband/src/semaphore/mod.rs
@@ -146,7 +146,9 @@ impl Semaphore {
     ///
     /// # Panics
     ///
-    /// Panics if adding the permits would cause the total number of permits to overflow.
+    /// Panics if adding the permits would cause the total number of permits to overflow or if a
+    /// registered waker panics while being notified. Added permits remain committed, and every
+    /// remaining registered waker is still notified before the first panic resumes.
     ///
     /// # Examples
     ///

--- a/asyncband/src/watch/mod.rs
+++ b/asyncband/src/watch/mod.rs
@@ -299,11 +299,14 @@ impl<T> Receiver<T> {
     /// version is marked observed by the call. Use [`Receiver::recv`] instead when the value is
     /// needed.
     pub async fn changed(&mut self) -> Result<(), RecvError> {
-        Changed {
-            receiver: self,
+        let seen = WaitForChange {
+            shared: &self.shared,
+            seen: self.seen,
             token: None,
         }
-        .await
+        .await?;
+        self.seen = seen;
+        Ok(())
     }
 
     /// Waits for a newer version, returns a clone of its latest value, and marks it observed.
@@ -315,12 +318,18 @@ impl<T> Receiver<T> {
     ///
     /// The clone is created while publication is locked. Keep `T::clone` inexpensive and avoid
     /// reentering this channel from the clone implementation. Use `T = Arc<U>` when the underlying
-    /// state is expensive to clone.
+    /// state is expensive to clone. If cloning panics, the version remains unseen and may be
+    /// received by a later call.
     pub async fn recv(&mut self) -> Result<T, RecvError>
     where
         T: Clone,
     {
-        self.changed().await?;
+        WaitForChange {
+            shared: &self.shared,
+            seen: self.seen,
+            token: None,
+        }
+        .await?;
         let state = self.shared.state.lock();
         let value = state.value.clone();
         self.seen = state.version;
@@ -336,22 +345,22 @@ impl<T> Receiver<T> {
     }
 }
 
-struct Changed<'a, T> {
-    receiver: &'a mut Receiver<T>,
+struct WaitForChange<'a, T> {
+    shared: &'a Shared<T>,
+    seen: u64,
     token: Option<WakerToken>,
 }
 
-impl<T> Future for Changed<'_, T> {
-    type Output = Result<(), RecvError>;
+impl<T> Future for WaitForChange<'_, T> {
+    type Output = Result<u64, RecvError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
         let (poll, retired_waker) = {
-            let mut state = this.receiver.shared.state.lock();
-            if state.version != this.receiver.seen {
+            let mut state = this.shared.state.lock();
+            if state.version != this.seen {
                 let retired = state.waiters.unregister(&mut this.token);
-                this.receiver.seen = state.version;
-                (Poll::Ready(Ok(())), retired)
+                (Poll::Ready(Ok(state.version)), retired)
             } else if state.senders == 0 {
                 let retired = state.waiters.unregister(&mut this.token);
                 (Poll::Ready(Err(RecvError::Disconnected)), retired)
@@ -365,14 +374,14 @@ impl<T> Future for Changed<'_, T> {
     }
 }
 
-impl<T> Drop for Changed<'_, T> {
+impl<T> Drop for WaitForChange<'_, T> {
     fn drop(&mut self) {
         if self.token.is_none() {
             return;
         }
 
         let waker = {
-            let mut state = self.receiver.shared.state.lock();
+            let mut state = self.shared.state.lock();
             state.waiters.unregister(&mut self.token)
         };
         drop(waker);

--- a/asyncband/src/watch/mod.rs
+++ b/asyncband/src/watch/mod.rs
@@ -299,7 +299,7 @@ impl<T> Receiver<T> {
     /// version is marked observed by the call. Use [`Receiver::recv`] instead when the value is
     /// needed.
     pub async fn changed(&mut self) -> Result<(), RecvError> {
-        let seen = WaitForChange {
+        let seen = Change {
             shared: &self.shared,
             seen: self.seen,
             token: None,
@@ -324,7 +324,7 @@ impl<T> Receiver<T> {
     where
         T: Clone,
     {
-        WaitForChange {
+        Change {
             shared: &self.shared,
             seen: self.seen,
             token: None,
@@ -345,13 +345,13 @@ impl<T> Receiver<T> {
     }
 }
 
-struct WaitForChange<'a, T> {
+struct Change<'a, T> {
     shared: &'a Shared<T>,
     seen: u64,
     token: Option<WakerToken>,
 }
 
-impl<T> Future for WaitForChange<'_, T> {
+impl<T> Future for Change<'_, T> {
     type Output = Result<u64, RecvError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -374,7 +374,7 @@ impl<T> Future for WaitForChange<'_, T> {
     }
 }
 
-impl<T> Drop for WaitForChange<'_, T> {
+impl<T> Drop for Change<'_, T> {
     fn drop(&mut self) {
         if self.token.is_none() {
             return;

--- a/tests-integration/tests/semaphore_test.rs
+++ b/tests-integration/tests/semaphore_test.rs
@@ -18,6 +18,8 @@
 use std::future::Future;
 use std::pin::pin;
 use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 use std::task::Context;
 use std::task::Poll;
 use std::task::Wake;
@@ -195,6 +197,62 @@ fn wake_then_drop() {
         }
     }
     assert_eq!(s.available_permits(), 2);
+}
+
+#[test]
+fn release_attempts_every_waker_after_one_panics() {
+    struct PanicOnWake;
+
+    impl Wake for PanicOnWake {
+        fn wake(self: Arc<Self>) {
+            panic!("waker panicked");
+        }
+    }
+
+    struct CountWakes(AtomicUsize);
+
+    impl Wake for CountWakes {
+        fn wake(self: Arc<Self>) {
+            self.0.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    let semaphore = Semaphore::new(0);
+    let mut panicking = pin!(semaphore.acquire(1));
+    let mut tracked = pin!(semaphore.acquire(1));
+    let panic_waker = Waker::from(Arc::new(PanicOnWake));
+    let wake_count = Arc::new(CountWakes(AtomicUsize::new(0)));
+    let tracked_waker = Waker::from(wake_count.clone());
+
+    assert!(
+        panicking
+            .as_mut()
+            .poll(&mut Context::from_waker(&panic_waker))
+            .is_pending()
+    );
+    assert!(
+        tracked
+            .as_mut()
+            .poll(&mut Context::from_waker(&tracked_waker))
+            .is_pending()
+    );
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| semaphore.release(2)));
+
+    assert!(result.is_err());
+    assert_eq!(wake_count.0.load(Ordering::Relaxed), 1);
+    assert!(
+        panicking
+            .as_mut()
+            .poll(&mut Context::from_waker(Waker::noop()))
+            .is_ready()
+    );
+    assert!(
+        tracked
+            .as_mut()
+            .poll(&mut Context::from_waker(Waker::noop()))
+            .is_ready()
+    );
 }
 
 #[test]

--- a/tests-integration/tests/watch_test.rs
+++ b/tests-integration/tests/watch_test.rs
@@ -19,6 +19,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::task::Context;
@@ -84,6 +85,24 @@ impl Drop for ReentrantDrop {
     }
 }
 
+struct PanicOnceClone {
+    value: usize,
+    panic_next: Arc<AtomicBool>,
+}
+
+impl Clone for PanicOnceClone {
+    fn clone(&self) -> Self {
+        assert!(
+            !self.panic_next.swap(false, Ordering::Relaxed),
+            "clone failed"
+        );
+        Self {
+            value: self.value,
+            panic_next: self.panic_next.clone(),
+        }
+    }
+}
+
 fn poll_with<F: Future>(future: Pin<&mut F>, waker: &Waker) -> Poll<F::Output> {
     future.poll(&mut Context::from_waker(waker))
 }
@@ -122,6 +141,29 @@ fn get_does_not_consume_but_recv_does() {
     assert_eq!(rx.has_changed(), Ok(true));
     assert_eq!(pollster::block_on(rx.recv()).unwrap(), 1);
     assert_eq!(rx.has_changed(), Ok(false));
+}
+
+#[test]
+fn panicking_clone_leaves_the_update_unseen() {
+    let panic_next = Arc::new(AtomicBool::new(false));
+    let (tx, mut rx) = watch::channel(PanicOnceClone {
+        value: 0,
+        panic_next: panic_next.clone(),
+    });
+    tx.send(PanicOnceClone {
+        value: 1,
+        panic_next: panic_next.clone(),
+    })
+    .unwrap();
+    panic_next.store(true, Ordering::Relaxed);
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        pollster::block_on(rx.recv())
+    }));
+
+    assert!(result.is_err());
+    assert_eq!(rx.has_changed(), Ok(true));
+    assert_eq!(pollster::block_on(rx.recv()).unwrap().value, 1);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- wake every semaphore waiter whose permit was granted even when another registered waker panics
- leave a watch update unseen until cloning succeeds so a receiver can recover and retry
- clarify the shipped semaphore panic-recovery fix in the 0.7 changelog
- require release-tag comparison before agents add future changelog entries

## Design Notes

The changes are limited to two reproduced failure modes and do not add or alter public API surface. The shared fan-out helper remains in `internal::waitset`; its conditional compilation now covers semaphore-backed single-feature builds. The watch correction is intentionally omitted from the changelog because watch has not shipped yet. Repository guidance now makes that release-baseline distinction explicit.

## Validation

- `cargo x lint`
- `cargo x check`
- `cargo x test --no-capture`
- `RUSTUP_TOOLCHAIN=1.86.0 cargo x test --no-capture`
- `cargo x semver --release-version 0.7.0 --acknowledge-breaking-changes`
- `cargo publish --package asyncband --locked --dry-run`
- `cargo x miri`
