### PR TITLE
fix(mpsc): recover AtomicWaker after clone panic

### DIFF
--- a/asyncband/src/internal/atomic_waker.rs
+++ b/asyncband/src/internal/atomic_waker.rs
@@ -25,6 +25,7 @@ use std::panic::AssertUnwindSafe;
 use std::panic::RefUnwindSafe;
 use std::panic::UnwindSafe;
 use std::panic::catch_unwind;
+use std::panic::resume_unwind;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::task::Waker;
@@ -74,18 +75,6 @@ pub struct AtomicWaker {
 // SAFETY: `state` grants exclusive access to `waker`, and losing concurrent registrations do not
 // touch the slot. `Waker` itself is `Send + Sync`.
 unsafe impl Sync for AtomicWaker {}
-
-struct RegisterGuard<'a>(&'a AtomicWaker);
-
-impl Drop for RegisterGuard<'_> {
-    fn drop(&mut self) {
-        // SAFETY: this guard exists only while `register_locked` owns the REGISTERING state. It is
-        // forgotten as soon as cloning succeeds, so Drop runs only while unwinding from clone.
-        if let Some(waker) = unsafe { self.0.finish_registration() } {
-            let _ = catch_unwind(AssertUnwindSafe(|| waker.wake()));
-        }
-    }
-}
 
 // `Waker` callbacks may unwind, but no panic leaves a state bit owned by the unwinding operation. A
 // failed clone leaves the old slot intact and completes any raced wake, while wake and drop
@@ -150,19 +139,50 @@ impl AtomicWaker {
             None => true,
         };
 
+        let mut clone_panic = None;
         let old_waker = if needs_replacement {
-            let guard = RegisterGuard(self);
-            let new_waker = waker.clone();
-            std::mem::forget(guard);
-
-            // SAFETY: the caller owns the REGISTERING state and is the only slot accessor.
-            unsafe { (*self.waker.get()).replace(new_waker) }
+            match catch_unwind(AssertUnwindSafe(|| waker.clone())) {
+                Ok(new_waker) => unsafe { (*self.waker.get()).replace(new_waker) },
+                Err(payload) => {
+                    clone_panic = Some(payload);
+                    None
+                }
+            }
         } else {
             None
         };
 
-        // SAFETY: the caller owns the REGISTERING state and is the only slot accessor.
-        let concurrent_wake = unsafe { self.finish_registration() };
+        // ORDERING: Release publishes a newly registered waker when the CAS succeeds. If it fails,
+        // Acquire receives the concurrent notifier's Release publication before the wake is
+        // completed below. AcqRel is the weakest success ordering that permits an Acquire failure
+        // ordering, although its Acquire half is not otherwise relied upon on the success path.
+        let concurrent_wake = match self.state.compare_exchange(
+            REGISTERING,
+            WAITING,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            Ok(_) => None,
+            Err(state) => {
+                debug_assert_eq!(state, REGISTERING | WAKING);
+
+                // SAFETY: REGISTERING remains set, so this thread still owns the waker slot.
+                let registered = unsafe { (*self.waker.get()).take() };
+
+                // ORDERING: Acquire receives all coalesced wake publications. Release publishes
+                // the empty slot and makes it available to the next register or wake operation.
+                self.state.swap(WAITING, Ordering::AcqRel);
+                registered
+            }
+        };
+
+        if let Some(payload) = clone_panic {
+            // Preserve the original clone panic while still completing a wake that raced with it.
+            if let Some(waker) = concurrent_wake {
+                let _ = catch_unwind(AssertUnwindSafe(|| waker.wake()));
+            }
+            resume_unwind(payload);
+        }
 
         // User waker code runs only after the state machine is back in WAITING, so a panic cannot
         // leave the cell locked. If the wake raced with a replacement, notify both tasks: the
@@ -176,36 +196,6 @@ impl AtomicWaker {
         } else {
             // Drop a replaced waker only after releasing the state lock.
             drop(old_waker);
-        }
-    }
-
-    /// Returns the registered waker when a wake raced with registration and otherwise returns none.
-    ///
-    /// # Safety
-    ///
-    /// The caller must own the REGISTERING state and be the only thread accessing `waker`.
-    #[inline]
-    unsafe fn finish_registration(&self) -> Option<Waker> {
-        // ORDERING: Release publishes a newly registered waker when the CAS succeeds. If it fails,
-        // Acquire receives the concurrent notifier's Release publication before the wake is
-        // completed below. AcqRel is the weakest success ordering that permits an Acquire failure
-        // ordering, although its Acquire half is not otherwise relied upon on the success path.
-        match self
-            .state
-            .compare_exchange(REGISTERING, WAITING, Ordering::AcqRel, Ordering::Acquire)
-        {
-            Ok(_) => None,
-            Err(state) => {
-                debug_assert_eq!(state, REGISTERING | WAKING);
-
-                // SAFETY: REGISTERING remains set, so this thread still owns the waker slot.
-                let registered = unsafe { (*self.waker.get()).take() };
-
-                // ORDERING: Acquire receives all coalesced wake publications. Release publishes
-                // the empty slot and makes it available to the next register or wake operation.
-                self.state.swap(WAITING, Ordering::AcqRel);
-                registered
-            }
         }
     }
 

--- a/asyncband/src/internal/atomic_waker.rs
+++ b/asyncband/src/internal/atomic_waker.rs
@@ -17,6 +17,8 @@
 
 // This state machine is derived from the futures-rs `AtomicWaker`, licensed under
 // Apache-2.0 OR MIT: https://github.com/rust-lang/futures-rs/blob/0.3.34/futures-core/src/task/__internal/atomic_waker.rs.
+// Its panic recovery is informed by Tokio's `AtomicWaker`, licensed under MIT:
+// https://github.com/tokio-rs/tokio/blob/tokio-1.53.1/tokio/src/sync/task/atomic_waker.rs.
 
 use std::cell::UnsafeCell;
 use std::panic::AssertUnwindSafe;
@@ -73,8 +75,21 @@ pub struct AtomicWaker {
 // touch the slot. `Waker` itself is `Send + Sync`.
 unsafe impl Sync for AtomicWaker {}
 
-// Task waker cloning follows the executor contract and is treated as infallible. Wake and drop
-// callbacks run only after the operation has returned the state machine to WAITING.
+struct RegisterGuard<'a>(&'a AtomicWaker);
+
+impl Drop for RegisterGuard<'_> {
+    fn drop(&mut self) {
+        // SAFETY: this guard exists only while `register_locked` owns the REGISTERING state. It is
+        // forgotten as soon as cloning succeeds, so Drop runs only while unwinding from clone.
+        if let Some(waker) = unsafe { self.0.finish_registration() } {
+            let _ = catch_unwind(AssertUnwindSafe(|| waker.wake()));
+        }
+    }
+}
+
+// `Waker` callbacks may unwind, but no panic leaves a state bit owned by the unwinding operation. A
+// failed clone leaves the old slot intact and completes any raced wake, while wake and drop
+// callbacks run after that operation's critical section has been released.
 impl RefUnwindSafe for AtomicWaker {}
 impl UnwindSafe for AtomicWaker {}
 
@@ -136,35 +151,18 @@ impl AtomicWaker {
         };
 
         let old_waker = if needs_replacement {
+            let guard = RegisterGuard(self);
+            let new_waker = waker.clone();
+            std::mem::forget(guard);
+
             // SAFETY: the caller owns the REGISTERING state and is the only slot accessor.
-            unsafe { (*self.waker.get()).replace(waker.clone()) }
+            unsafe { (*self.waker.get()).replace(new_waker) }
         } else {
             None
         };
 
-        // ORDERING: Release publishes a newly registered waker when the CAS succeeds. If it fails,
-        // Acquire receives the concurrent notifier's Release publication before the wake is
-        // completed below. AcqRel is the weakest success ordering that permits an Acquire failure
-        // ordering, although its Acquire half is not otherwise relied upon on the success path.
-        let concurrent_wake = match self.state.compare_exchange(
-            REGISTERING,
-            WAITING,
-            Ordering::AcqRel,
-            Ordering::Acquire,
-        ) {
-            Ok(_) => None,
-            Err(state) => {
-                debug_assert_eq!(state, REGISTERING | WAKING);
-
-                // SAFETY: REGISTERING remains set, so this thread still owns the waker slot.
-                let registered = unsafe { (*self.waker.get()).take() };
-
-                // ORDERING: Acquire receives all coalesced wake publications. Release publishes
-                // the empty slot and makes it available to the next register or wake operation.
-                self.state.swap(WAITING, Ordering::AcqRel);
-                registered
-            }
-        };
+        // SAFETY: the caller owns the REGISTERING state and is the only slot accessor.
+        let concurrent_wake = unsafe { self.finish_registration() };
 
         // User waker code runs only after the state machine is back in WAITING, so a panic cannot
         // leave the cell locked. If the wake raced with a replacement, notify both tasks: the
@@ -178,6 +176,36 @@ impl AtomicWaker {
         } else {
             // Drop a replaced waker only after releasing the state lock.
             drop(old_waker);
+        }
+    }
+
+    /// Returns the registered waker when a wake raced with registration and otherwise returns none.
+    ///
+    /// # Safety
+    ///
+    /// The caller must own the REGISTERING state and be the only thread accessing `waker`.
+    #[inline]
+    unsafe fn finish_registration(&self) -> Option<Waker> {
+        // ORDERING: Release publishes a newly registered waker when the CAS succeeds. If it fails,
+        // Acquire receives the concurrent notifier's Release publication before the wake is
+        // completed below. AcqRel is the weakest success ordering that permits an Acquire failure
+        // ordering, although its Acquire half is not otherwise relied upon on the success path.
+        match self
+            .state
+            .compare_exchange(REGISTERING, WAITING, Ordering::AcqRel, Ordering::Acquire)
+        {
+            Ok(_) => None,
+            Err(state) => {
+                debug_assert_eq!(state, REGISTERING | WAKING);
+
+                // SAFETY: REGISTERING remains set, so this thread still owns the waker slot.
+                let registered = unsafe { (*self.waker.get()).take() };
+
+                // ORDERING: Acquire receives all coalesced wake publications. Release publishes
+                // the empty slot and makes it available to the next register or wake operation.
+                self.state.swap(WAITING, Ordering::AcqRel);
+                registered
+            }
         }
     }
 
@@ -237,6 +265,18 @@ mod tests {
         fn wake(self: Arc<Self>) {
             self.0.fetch_add(1, Ordering::Relaxed);
         }
+    }
+
+    #[cfg(panic = "unwind")]
+    fn clone_panicking_waker() -> Waker {
+        static VTABLE: RawWakerVTable = RawWakerVTable::new(
+            |_| panic!("clone failed"),
+            |_| unreachable!(),
+            |_| unreachable!(),
+            |_| {},
+        );
+
+        unsafe { Waker::from_raw(RawWaker::new(ptr::null(), &VTABLE)) }
     }
 
     #[test]
@@ -329,6 +369,59 @@ mod tests {
                 drop(local_waker);
             });
         }
+    }
+
+    #[cfg(panic = "unwind")]
+    #[test]
+    fn clone_panic_does_not_poison_state() {
+        let atomic_waker = AtomicWaker::new();
+
+        assert!(
+            catch_unwind(|| {
+                atomic_waker.register(&clone_panicking_waker());
+            })
+            .is_err()
+        );
+
+        let counter = Arc::new(WakeCounter(AtomicUsize::new(0)));
+        atomic_waker.register(&Waker::from(counter.clone()));
+        atomic_waker.wake();
+        assert_eq!(counter.0.load(Ordering::Relaxed), 1);
+    }
+
+    #[cfg(panic = "unwind")]
+    #[test]
+    fn clone_panic_completes_concurrent_wake() {
+        let counter = Arc::new(WakeCounter(AtomicUsize::new(0)));
+        let atomic_waker = AtomicWaker::new();
+        atomic_waker.register(&Waker::from(counter.clone()));
+
+        assert_eq!(
+            atomic_waker.state.compare_exchange(
+                WAITING,
+                REGISTERING,
+                Ordering::Acquire,
+                Ordering::Acquire,
+            ),
+            Ok(WAITING)
+        );
+        std::thread::scope(|scope| scope.spawn(|| atomic_waker.wake()).join().unwrap());
+
+        // SAFETY: this test acquired REGISTERING above and the waking thread has finished touching
+        // the state. Calling the helper completes the interrupted registration.
+        assert!(
+            catch_unwind(|| unsafe {
+                atomic_waker.register_locked(&clone_panicking_waker());
+            })
+            .is_err()
+        );
+
+        assert_eq!(counter.0.load(Ordering::Relaxed), 1);
+
+        let next_counter = Arc::new(WakeCounter(AtomicUsize::new(0)));
+        atomic_waker.register(&Waker::from(next_counter.clone()));
+        atomic_waker.wake();
+        assert_eq!(next_counter.0.load(Ordering::Relaxed), 1);
     }
 
     #[cfg(panic = "unwind")]


### PR DESCRIPTION
## Summary

- Restore `AtomicWaker` to a usable state when a custom `RawWaker` clone unwinds.
- Complete a wake that races with the failed registration while preserving the original panic.
- Cover both the uncontended and raced state transitions.

## Design Notes

The recovery remains in the registration control flow: capture a clone panic, return the state machine to `WAITING`, complete any raced wake, and then resume the original panic. This keeps the unwind invariant local instead of introducing a separate guard lifecycle.

With 50,000 samples of 1,000 iterations, repeated pending registration remained level with main (7.05 ns versus 7.17 ns median), while the worst-case pending receiver round trip that clones on every iteration measured 19.75 ns versus 19.04 ns on main. This exposes the roughly 0.7 ns cost for review against preserving the explicit unwind-safe contract.
