### PR TITLE
chore: prepare 0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## v0.7.0 (2026-09-01)
+
 ### Breaking changes
 
 * Gate all exported primitives behind opt-in Cargo features and enable no features by default; downstream dependencies must explicitly enable the APIs they use.
@@ -36,5 +38,7 @@ All notable changes to this project will be documented in this file.
 
 ### Improvements
 
-* Remove the `slab` dependency in favor of a focused internal waiter arena.
+* Reduce MPSC receiver registration and wake latency by storing receiver wakers inline instead of allocating them on the heap.
+* Reduce semaphore and mutex hot-path overhead by avoiding wake-buffer allocation when no tasks are queued and batching queued wakes on the stack.
+* Allocate `OnceMap` and `singleflight::Group` registries lazily to reduce construction overhead.
 * Describe disconnected channel states consistently in channel error messages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-## v0.7.0 (2026-09-01)
+## v0.7.0
 
 ### Breaking changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "asyncband"
-version = "0.6.7"
+version = "0.7.0"
 dependencies = [
  "hashbrown",
  "tokio",

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -56,7 +56,7 @@ The `release` environment in `.asf.yaml` limits deployments to version tags and 
 Start from current `main` and choose `VERSION` from the changes since the latest crates.io release.
 
 1. Change `version` in `asyncband/Cargo.toml` and refresh `Cargo.lock` with Cargo.
-2. Move the entries under `Unreleased` in `CHANGELOG.md` into a dated `VERSION` section, then restore an empty `Unreleased` section. Keep user-impacting sections ordered as breaking changes, new features, bug fixes, and improvements.
+2. Move the entries under `Unreleased` in `CHANGELOG.md` into an undated `v${VERSION}` section immediately below it, then restore an empty `Unreleased` section. Keep user-impacting sections ordered as breaking changes, new features, bug fixes, and improvements; add the actual release date only after publication.
 3. Verify `LICENSE`, `NOTICE`, `DISCLAIMER`, source headers, and bundled dependencies.
 4. Run the release checks:
 
@@ -85,7 +85,9 @@ Fetch `RELEASE_COMMIT`, inspect the detached worktree, and create a signed annot
 RC_TAG="v${VERSION}-rc.${RC}"
 git fetch https://github.com/apache/asyncband.git main
 git switch --detach "${RELEASE_COMMIT}"
-git status --short
+git grep -F "version = \"${VERSION}\"" -- asyncband/Cargo.toml Cargo.lock
+git grep -Fx "## v${VERSION}" -- CHANGELOG.md
+test -z "$(git status --porcelain)"
 git tag --sign "${RC_TAG}" \
   --message "Apache Asyncband ${VERSION} release candidate ${RC}" \
   "${RELEASE_COMMIT}"
@@ -201,8 +203,9 @@ After publication:
 
 1. Verify the version and metadata on crates.io and docs.rs.
 2. After ASF distribution syncs, verify the source archive, checksum, and signature under `https://downloads.apache.org/incubator/asyncband/${VERSION}/` and the project `KEYS` file at `https://downloads.apache.org/incubator/asyncband/KEYS`.
-3. Announce the release on `dev@asyncband.apache.org` and other appropriate channels as Apache Asyncband (Incubating).
-4. Remove superseded releases from `dist/release`; ASF retains them in the archive.
+3. Submit a post-release pull request that adds the actual publication date to the `v${VERSION}` changelog heading.
+4. Announce the release on `dev@asyncband.apache.org` and other appropriate channels as Apache Asyncband (Incubating).
+5. Remove superseded releases from `dist/release`; ASF retains them in the archive.
 
 ## Recover from failures
 

--- a/asyncband/Cargo.toml
+++ b/asyncband/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "asyncband"
-version = "0.6.7"
+version = "0.7.0"
 
 categories = ["asynchronous", "concurrency"]
 description = "Composable, runtime-agnostic concurrency building blocks for async Rust."


### PR DESCRIPTION
## Summary

- Bump `asyncband` to 0.7.0 and refresh `Cargo.lock`.
- Finalize an undated `v0.7.0` changelog section and leave `Unreleased` empty.
- Verify the undated heading before creating an RC and add the actual date through a post-release pull request.
- Freeze the release scope at `fba31fd`; open feature work remains deferred under #227.

## Validation

- `cargo x check`
- `cargo x semver --release-version 0.7.0 --acknowledge-breaking-changes`
- `cargo x lint`
- `cargo x test --no-capture`
- `RUSTUP_TOOLCHAIN=1.86.0 cargo x test --no-capture`
- `cargo x miri`
- `cargo publish --package asyncband --locked --dry-run`

Refs #227
