### PR TITLE
build: exclude Cargo target from Typos

### DIFF
--- a/licenserc.toml
+++ b/licenserc.toml
@@ -19,5 +19,4 @@
 builtin = "Apache-2.0-ASF"
 
 [files]
-excludes = ["target/**"]
 includes = ["**/*.proto", "**/*.rs", "**/*.yml", "**/*.yaml", "**/*.toml"]

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -19,4 +19,5 @@
 builtin = "Apache-2.0-ASF"
 
 [files]
+excludes = ["target/**"]
 includes = ["**/*.proto", "**/*.rs", "**/*.yml", "**/*.yaml", "**/*.toml"]

--- a/typos.toml
+++ b/typos.toml
@@ -18,4 +18,4 @@
 [default.extend-words]
 
 [files]
-extend-exclude = []
+extend-exclude = ["/target"]


### PR DESCRIPTION
## Summary

- Explicitly exclude the root Cargo `target` directory from Typos scans.
- Keep `cargo x lint` working in exported source trees where Git metadata is unavailable.
- Rely on HawkEye 7.0.1 to honor the archive's `.gitignore` during filesystem fallback; verified with the official 7.0.1 binary in a Git-free source archive.
