### PR TITLE
perf(countdown): avoid spinning before waiter registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Improvements
+
+* Avoid fixed CPU spinning before registering `WaitGroup`, `Latch`, and `Once` waiters.
+
 ## v0.7.0
 
 ### Breaking changes

--- a/asyncband/src/internal/countdown.rs
+++ b/asyncband/src/internal/countdown.rs
@@ -65,7 +65,7 @@ impl CountdownState {
 
     /// Polls for zero, registering the current waker if the countdown is still active.
     pub fn poll_wait(&self, token: &mut Option<WakerToken>, cx: &mut Context<'_>) -> Poll<()> {
-        if self.spin_wait(16).is_ok() {
+        if self.try_wait().is_ok() {
             // The zero transition owns draining this wake epoch. Avoid taking the waiter lock
             // again when the completed future is dropped.
             *token = None;
@@ -96,16 +96,8 @@ impl CountdownState {
         }
     }
 
-    /// Returns `Ok(())` if the counter is zero, otherwise returns `Err(s)` where `s` is the current
-    /// counter value.
-    pub fn spin_wait(&self, n: usize) -> Result<(), u32> {
-        for _ in 0..n {
-            if self.state() == 0 {
-                return Ok(());
-            }
-            std::hint::spin_loop();
-        }
-
+    /// Returns `Ok(())` if the counter is zero, otherwise returns the current counter value.
+    pub fn try_wait(&self) -> Result<(), u32> {
         match self.state() {
             0 => Ok(()),
             s => Err(s),

--- a/asyncband/src/latch/mod.rs
+++ b/asyncband/src/latch/mod.rs
@@ -153,7 +153,7 @@ impl Latch {
     /// assert_eq!(latch.try_wait(), Ok(()));
     /// ```
     pub fn try_wait(&self) -> Result<(), u32> {
-        self.state.spin_wait(0)
+        self.state.try_wait()
     }
 
     /// Returns a future that will complete when the latch count reaches zero.

--- a/asyncband/src/once/once/mod.rs
+++ b/asyncband/src/once/once/mod.rs
@@ -125,7 +125,7 @@ impl Once {
     /// # }
     /// ```
     pub fn is_completed(&self) -> bool {
-        self.done.spin_wait(0).is_ok()
+        self.done.try_wait().is_ok()
     }
 
     /// Calls the given async closure if this is the first time `call_once` has been called


### PR DESCRIPTION
## Summary

- remove the fixed 16-iteration CPU spin before countdown waiter registration
- retain the locked state recheck and waker registration protocol
- reuse a single non-spinning `try_wait` helper for `WaitGroup`, `Latch`, and `Once`

The fixed spin runs on every pending first poll, while it can only avoid registration in a narrow race where another thread completes the countdown during those iterations. Removing it reduces deterministic pending-path CPU work without changing wakeup or memory-ordering semantics.

## Linux benchmarks

Measured on the same `linux/aarch64` Docker host with Rust 1.86.0 (Debian Bookworm), comparing `main` at `2745639` with this branch. Each run used 1,000 Divan samples; values below are the median of four post-warmup runs.

| Benchmark | main | this PR | change |
| --- | ---: | ---: | ---: |
| `Latch::cancel_pending` | 143.6 ns | 18.0 ns | -87.5% |
| `Once::cancel_pending_wait` | 148.2 ns | 20.4 ns | -86.2% |
| `WaitGroup::cancel_pending` | 169.7 ns | 33.6 ns | -80.2% |
| `Latch::waiter_fan_out(32)` | 4.728 µs | 656 ns | -86.1% |
| `Once::complete_waiter_batch(32)` | 4.666 µs | 695 ns | -85.1% |
| `WaitGroup::complete_waiter_batch(32)` | 4.603 µs | 706 ns | -84.7% |

## Validation

- `cargo x test`
- `cargo x check`
- `cargo x lint`
- `cargo x bench`
