### PR TITLE
ci: publish release candidates to crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
     timeout-minutes: 30
     outputs:
       version: ${{ steps.package.outputs.version }}
+      publish_version: ${{ steps.package.outputs.publish_version }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -59,7 +60,12 @@ jobs:
             echo "The asyncband package version must be a stable X.Y.Z version, got: ${version}" >&2
             exit 1
           fi
+          publish_version="${version}"
+          if [[ "${GITHUB_REF_NAME}" == "v${version}-rc."* ]]; then
+            publish_version="${GITHUB_REF_NAME#v}"
+          fi
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "publish_version=${publish_version}" >> "${GITHUB_OUTPUT}"
       - name: Check tag
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         shell: bash
@@ -87,12 +93,26 @@ jobs:
             echo "Release tag ${GITHUB_REF_NAME} does not point to a commit on main." >&2
             exit 1
           fi
+      - name: Prepare crates.io release candidate
+        if: ${{ steps.package.outputs.publish_version != steps.package.outputs.version }}
+        shell: bash
+        env:
+          PACKAGE_VERSION: ${{ steps.package.outputs.version }}
+          PUBLISH_VERSION: ${{ steps.package.outputs.publish_version }}
+        run: |
+          perl -pi -e 's/^version = "\Q$ENV{PACKAGE_VERSION}\E"$/version = "$ENV{PUBLISH_VERSION}"/' asyncband/Cargo.toml
+          grep -Fx "version = \"${PUBLISH_VERSION}\"" asyncband/Cargo.toml
+          cargo check --package asyncband
       - name: Check crates.io package
+        if: ${{ steps.package.outputs.publish_version == steps.package.outputs.version }}
         run: cargo publish --package asyncband --locked --dry-run
+      - name: Check crates.io release candidate
+        if: ${{ steps.package.outputs.publish_version != steps.package.outputs.version }}
+        run: cargo publish --package asyncband --locked --dry-run --allow-dirty
 
   publish:
     name: Publish to crates.io
-    if: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name == format('v{0}', needs.check.outputs.version) }}
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
     needs: check
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -107,10 +127,22 @@ jobs:
           rustup toolchain install stable
           --profile minimal
           --no-self-update
+      - name: Prepare crates.io release candidate
+        if: ${{ needs.check.outputs.publish_version != needs.check.outputs.version }}
+        shell: bash
+        env:
+          PACKAGE_VERSION: ${{ needs.check.outputs.version }}
+          PUBLISH_VERSION: ${{ needs.check.outputs.publish_version }}
+        run: |
+          perl -pi -e 's/^version = "\Q$ENV{PACKAGE_VERSION}\E"$/version = "$ENV{PUBLISH_VERSION}"/' asyncband/Cargo.toml
+          grep -Fx "version = \"${PUBLISH_VERSION}\"" asyncband/Cargo.toml
+          cargo check --package asyncband
       - id: auth
         name: Authenticate with crates.io
         uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
       - name: Publish asyncband
-        run: cargo publish --package asyncband --locked
+        run: >-
+          cargo publish --package asyncband --locked
+          ${{ needs.check.outputs.publish_version != needs.check.outputs.version && '--allow-dirty' || '' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -94,7 +94,7 @@ git tag --sign "${RC_TAG}" \
 git push https://github.com/apache/asyncband.git "${RC_TAG}"
 ```
 
-Wait for the `Release` GitHub Actions workflow to pass. An RC tag runs package validation and skips the crates.io publishing job. A candidate that needs a code change gets a new release pull request, merge commit, RC number, and signed tag.
+Wait for the `Release` GitHub Actions workflow to pass. The workflow publishes a convenience prerelease named `${VERSION}-rc.${RC}` to crates.io while the source tag and release candidate retain the stable `${VERSION}` package version. A candidate that needs a code change gets a new release pull request, merge commit, RC number, and signed tag.
 
 ## 3. Build and verify the source archive
 


### PR DESCRIPTION
## Summary

- derive the crates.io prerelease version from `vX.Y.Z-rc.N` tags
- publish RC crates through the existing trusted-publishing workflow
- keep the tagged source at the stable `X.Y.Z` version used by the ASF source candidate

This follows the Apache DataSketches Rust release process: the crates.io prerelease is prepared by temporarily changing only the package version and lockfile, while the immutable RC tag remains unchanged.

## Validation

- `cargo x lint` (Clippy and rustfmt passed; Taplo panicked in macOS system configuration before the remaining checks)
- parsed `.github/workflows/release.yml` with Ruby YAML
- simulated `0.7.0` to `0.7.0-rc.2` conversion in a temporary checkout
- `cargo check --package asyncband` and locked metadata resolution passed for the simulated RC
