### PR TITLE
fix: correct derived source license headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Bug fixes
+
+* Correct source-header treatment and make third-party derivation and test provenance records more precise in source distributions.
+
 ## v0.7.0
 
 ### Breaking changes

--- a/LICENSE
+++ b/LICENSE
@@ -259,17 +259,28 @@ The Apache License, Version 2.0, reproduced above, applies to the upstream
 portions identified below. Where an upstream project offers a choice of
 Apache-2.0 or MIT, Apache Asyncband uses the Apache-2.0 option.
 
-Portions of the following files are derived from the oneshot crate at commit
-83fd0864be7289067ce96cc79cd96c0928742979:
+Portions of the following implementation files are derived from the oneshot
+crate at commit 83fd0864be7289067ce96cc79cd96c0928742979:
 
   asyncband/src/oneshot/mod.rs
   asyncband/src/oneshot/receiver.rs
   asyncband/src/oneshot/sender.rs
+
+Portions of the following test files and support are adapted from the same
+upstream test suite:
+
   asyncband/src/oneshot/tests.rs
   tests-integration/tests/oneshot_test/main.rs
+  tests-integration/tests/oneshot_test/support.rs
 
 The oneshot crate is available from https://github.com/faern/oneshot and is
-licensed under Apache-2.0 or MIT.
+licensed under Apache-2.0 or MIT. The corresponding upstream tests are:
+
+  https://github.com/faern/oneshot/blob/83fd0864be7289067ce96cc79cd96c0928742979/tests/async.rs
+  https://github.com/faern/oneshot/blob/83fd0864be7289067ce96cc79cd96c0928742979/tests/future.rs
+  https://github.com/faern/oneshot/blob/83fd0864be7289067ce96cc79cd96c0928742979/tests/miri.rs
+  https://github.com/faern/oneshot/blob/83fd0864be7289067ce96cc79cd96c0928742979/tests/sync.rs
+  https://github.com/faern/oneshot/tree/83fd0864be7289067ce96cc79cd96c0928742979/tests/helpers
 
 Portions of asyncband/src/internal/atomic_waker.rs are derived from futures-rs
 0.3.34 at commit 705e6b5c0f06535b1aac1cb1989a172b3d45be8c, available from

--- a/asyncband/src/blocking/parker.rs
+++ b/asyncband/src/blocking/parker.rs
@@ -1,20 +1,3 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
 // Adapted from parking 2.2.1 at commit 0ece32dbfd6cd1bc1510ede6ed56acb772edf83f:
 // https://github.com/smol-rs/parking/blob/0ece32dbfd6cd1bc1510ede6ed56acb772edf83f/src/lib.rs#L327-L429
 

--- a/asyncband/src/internal/atomic_waker.rs
+++ b/asyncband/src/internal/atomic_waker.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from futures-rs 0.3.34, with panic recovery informed by Tokio 1.53.1:
+// Portions derived from futures-rs 0.3.34, with panic recovery informed by Tokio 1.53.1:
 // https://github.com/rust-lang/futures-rs/blob/705e6b5c0f06535b1aac1cb1989a172b3d45be8c/futures-core/src/task/__internal/atomic_waker.rs
 // https://github.com/tokio-rs/tokio/blob/75fef53d0a8590c2d1dbb63672aa7b7d1ef51155/tokio/src/sync/task/atomic_waker.rs
 

--- a/asyncband/src/mutex/mod.rs
+++ b/asyncband/src/mutex/mod.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from Tokio 1.41.0:
+// Portions derived from Tokio 1.41.0:
 // https://github.com/tokio-rs/tokio/blob/01e04daaa162ce6122bb894fdda0b6803dd32093/tokio/src/sync/mutex.rs
 
 //! An async mutex for protecting shared data.

--- a/asyncband/src/oneshot/mod.rs
+++ b/asyncband/src/oneshot/mod.rs
@@ -15,7 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from the oneshot crate at commit 83fd0864:
+// Portions derived from the oneshot crate at commit
+// 83fd0864be7289067ce96cc79cd96c0928742979:
 // https://github.com/faern/oneshot/blob/83fd0864be7289067ce96cc79cd96c0928742979/src/lib.rs
 
 //! A one-shot channel is used for sending a single message between asynchronous tasks. The

--- a/asyncband/src/oneshot/receiver.rs
+++ b/asyncband/src/oneshot/receiver.rs
@@ -15,7 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from the oneshot crate at commit 83fd0864:
+// Portions derived from the oneshot crate at commit
+// 83fd0864be7289067ce96cc79cd96c0928742979:
 // https://github.com/faern/oneshot/blob/83fd0864be7289067ce96cc79cd96c0928742979/src/lib.rs
 
 use std::fmt;

--- a/asyncband/src/oneshot/sender.rs
+++ b/asyncband/src/oneshot/sender.rs
@@ -15,7 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from the oneshot crate at commit 83fd0864:
+// Portions derived from the oneshot crate at commit
+// 83fd0864be7289067ce96cc79cd96c0928742979:
 // https://github.com/faern/oneshot/blob/83fd0864be7289067ce96cc79cd96c0928742979/src/lib.rs
 
 use std::any::type_name;

--- a/asyncband/src/oneshot/tests.rs
+++ b/asyncband/src/oneshot/tests.rs
@@ -15,8 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from the oneshot crate at commit 83fd0864:
-// https://github.com/faern/oneshot/blob/83fd0864be7289067ce96cc79cd96c0928742979/src/lib.rs
+// Portions of the test support are adapted from the oneshot crate at commit
+// 83fd0864be7289067ce96cc79cd96c0928742979:
+// https://github.com/faern/oneshot/tree/83fd0864be7289067ce96cc79cd96c0928742979/tests/helpers
 
 use std::future::Future;
 use std::future::IntoFuture;

--- a/asyncband/src/rwlock/mapped_read_guard.rs
+++ b/asyncband/src/rwlock/mapped_read_guard.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from Tokio 1.42.0's RwLock implementation:
+// Portions derived from Tokio 1.42.0's RwLock implementation:
 // https://github.com/tokio-rs/tokio/tree/bb9d57017e100985f86d8ca41ac105ee9140423e/tokio/src/sync/rwlock
 
 use std::fmt;

--- a/asyncband/src/rwlock/mapped_write_guard.rs
+++ b/asyncband/src/rwlock/mapped_write_guard.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from Tokio 1.42.0's RwLock implementation:
+// Portions derived from Tokio 1.42.0's RwLock implementation:
 // https://github.com/tokio-rs/tokio/tree/bb9d57017e100985f86d8ca41ac105ee9140423e/tokio/src/sync/rwlock
 
 use std::fmt;

--- a/asyncband/src/rwlock/mod.rs
+++ b/asyncband/src/rwlock/mod.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from Tokio 1.42.0:
+// Portions derived from Tokio 1.42.0:
 // https://github.com/tokio-rs/tokio/blob/bb9d57017e100985f86d8ca41ac105ee9140423e/tokio/src/sync/rwlock.rs
 
 //! A reader-writer lock that allows multiple readers or a single writer at a time.

--- a/asyncband/src/rwlock/owned_mapped_read_guard.rs
+++ b/asyncband/src/rwlock/owned_mapped_read_guard.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from Tokio 1.42.0's RwLock implementation:
+// Portions derived from Tokio 1.42.0's RwLock implementation:
 // https://github.com/tokio-rs/tokio/tree/bb9d57017e100985f86d8ca41ac105ee9140423e/tokio/src/sync/rwlock
 
 use std::fmt;

--- a/asyncband/src/rwlock/owned_mapped_write_guard.rs
+++ b/asyncband/src/rwlock/owned_mapped_write_guard.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from Tokio 1.42.0's RwLock implementation:
+// Portions derived from Tokio 1.42.0's RwLock implementation:
 // https://github.com/tokio-rs/tokio/tree/bb9d57017e100985f86d8ca41ac105ee9140423e/tokio/src/sync/rwlock
 
 use std::fmt;

--- a/asyncband/src/rwlock/owned_read_guard.rs
+++ b/asyncband/src/rwlock/owned_read_guard.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from Tokio 1.42.0's RwLock implementation:
+// Portions derived from Tokio 1.42.0's RwLock implementation:
 // https://github.com/tokio-rs/tokio/tree/bb9d57017e100985f86d8ca41ac105ee9140423e/tokio/src/sync/rwlock
 
 use std::fmt;

--- a/asyncband/src/rwlock/owned_write_guard.rs
+++ b/asyncband/src/rwlock/owned_write_guard.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from Tokio 1.42.0's RwLock implementation:
+// Portions derived from Tokio 1.42.0's RwLock implementation:
 // https://github.com/tokio-rs/tokio/tree/bb9d57017e100985f86d8ca41ac105ee9140423e/tokio/src/sync/rwlock
 
 use std::fmt;

--- a/asyncband/src/rwlock/read_guard.rs
+++ b/asyncband/src/rwlock/read_guard.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from Tokio 1.42.0's RwLock implementation:
+// Portions derived from Tokio 1.42.0's RwLock implementation:
 // https://github.com/tokio-rs/tokio/tree/bb9d57017e100985f86d8ca41ac105ee9140423e/tokio/src/sync/rwlock
 
 use std::fmt;

--- a/asyncband/src/rwlock/write_guard.rs
+++ b/asyncband/src/rwlock/write_guard.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from Tokio 1.42.0's RwLock implementation:
+// Portions derived from Tokio 1.42.0's RwLock implementation:
 // https://github.com/tokio-rs/tokio/tree/bb9d57017e100985f86d8ca41ac105ee9140423e/tokio/src/sync/rwlock
 
 use std::fmt;

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -19,4 +19,6 @@
 builtin = "Apache-2.0-ASF"
 
 [files]
+# This adapted third-party source intentionally does not carry the ASF source header.
+excludes = ["asyncband/src/blocking/parker.rs"]
 includes = ["**/*.proto", "**/*.rs", "**/*.yml", "**/*.yaml", "**/*.toml"]

--- a/tests-integration/tests/oneshot_test/main.rs
+++ b/tests-integration/tests/oneshot_test/main.rs
@@ -15,8 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from the oneshot crate at commit 83fd0864:
-// https://github.com/faern/oneshot/blob/83fd0864be7289067ce96cc79cd96c0928742979/src/lib.rs
+// Portions of these tests are adapted from the oneshot crate at commit
+// 83fd0864be7289067ce96cc79cd96c0928742979:
+// https://github.com/faern/oneshot/blob/83fd0864be7289067ce96cc79cd96c0928742979/tests/async.rs
+// https://github.com/faern/oneshot/blob/83fd0864be7289067ce96cc79cd96c0928742979/tests/future.rs
+// https://github.com/faern/oneshot/blob/83fd0864be7289067ce96cc79cd96c0928742979/tests/miri.rs
+// https://github.com/faern/oneshot/blob/83fd0864be7289067ce96cc79cd96c0928742979/tests/sync.rs
 
 use std::future::Future;
 use std::future::IntoFuture;

--- a/tests-integration/tests/oneshot_test/support.rs
+++ b/tests-integration/tests/oneshot_test/support.rs
@@ -15,6 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// Portions of this test support are adapted from the oneshot crate at commit
+// 83fd0864be7289067ce96cc79cd96c0928742979:
+// https://github.com/faern/oneshot/tree/83fd0864be7289067ce96cc79cd96c0928742979/tests/helpers
+
 use std::hint::spin_loop;
 use std::sync::Arc;
 use std::sync::atomic::AtomicU32;


### PR DESCRIPTION
## Summary

- remove the ASF header from the directly adapted private parker and exclude that exact file from Hawkeye's ASF-header check
- retain ASF headers on files with major Asyncband modifications while describing the incorporated upstream code as scoped portions
- correct OneShot test provenance to reference the actual upstream test suite and include its shared support file

## Design Notes

The review compared the current files with the pinned Tokio, futures-rs, oneshot, Pollster, futures-lite, parking, and Fastpool commits recorded in `LICENSE` and `HISTORY.md`.

`blocking/parker.rs` closely adapts parking's private state machine, so it is treated as third-party source and does not carry the ASF header. `blocking/mod.rs` retains the header because only its polling and cache patterns are adapted. AtomicWaker, Mutex/RwLock, OneShot, and Pool retain the header because their current files contain major Asyncband implementation, API, safety, or lifecycle changes; their provenance notices now describe only the incorporated portions.

The private OneShot `AWAKING` regression tests are Asyncband-specific. Only their support lineage is attributed upstream, while the integration tests link to the actual upstream async, future, Miri, sync, and helper sources at the pinned commit.

## Validation

- `cargo +nightly clippy --tests --all-features --all-targets --workspace -- -D warnings`
- `cargo +nightly fmt --all --check`
- `hawkeye check`
- `typos`
- `RUSTDOCFLAGS='-D warnings --cfg docsrs' cargo +nightly doc --workspace --all-features --no-deps`
- `cargo x test`
- `cargo package --package asyncband --locked --list --allow-dirty`
