### PR TITLE
chore: prepare non-ASF 0.7.1 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,11 @@ jobs:
 
   publish:
     name: Publish to crates.io
-    if: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name == format('v{0}', needs.check.outputs.version) }}
+    # v0.7.1 is an interim non-ASF release published outside ASF release infrastructure.
+    if: >-
+      ${{ startsWith(github.ref, 'refs/tags/') &&
+          github.ref_name == format('v{0}', needs.check.outputs.version) &&
+          github.ref_name != 'v0.7.1' }}
     needs: check
     runs-on: ubuntu-24.04
     timeout-minutes: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## v0.7.1
+
+This is an interim non-ASF release. It has not been approved by the Apache Incubator PMC and is not an act of the Apache Software Foundation.
+
 ### Bug fixes
 
 * Correct source-header treatment and make third-party derivation and test provenance records more precise in source distributions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Bug fixes
+
+* Correct source-header treatment and make third-party derivation and test provenance records more precise in source distributions.
+
 ## v0.7.0
 
 ### Breaking changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "asyncband"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "hashbrown",
  "tokio",

--- a/DISCLAIMER
+++ b/DISCLAIMER
@@ -1,5 +1,0 @@
-Apache Asyncband (Incubating) is an effort undergoing incubation at the Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
-
-Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects.
-
-While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.

--- a/DISCLAIMER-WIP
+++ b/DISCLAIMER-WIP
@@ -1,0 +1,8 @@
+Apache Asyncband is an effort undergoing incubation at The Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC. Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision-making process have stabilized in a manner consistent with other successful ASF projects. While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
+
+Some of the incubating project's releases may not be fully compliant with ASF policy. The following issues are known for version 0.7.1:
+
+- Version 0.7.1 is an interim non-ASF release. It has not been approved by the Apache Incubator PMC and is not an act of the ASF.
+- The third-party provenance and source-header corrections included in version 0.7.1 have not been reviewed or approved through an ASF release vote.
+
+If you are planning to incorporate this work into your product or project, please conduct a thorough licensing review to determine the overall implications of including it. For the current status of Apache Asyncband in the Apache Incubator, visit https://incubator.apache.org/projects/asyncband.html.

--- a/LICENSE
+++ b/LICENSE
@@ -259,17 +259,28 @@ The Apache License, Version 2.0, reproduced above, applies to the upstream
 portions identified below. Where an upstream project offers a choice of
 Apache-2.0 or MIT, Apache Asyncband uses the Apache-2.0 option.
 
-Portions of the following files are derived from the oneshot crate at commit
-83fd0864be7289067ce96cc79cd96c0928742979:
+Portions of the following implementation files are derived from the oneshot
+crate at commit 83fd0864be7289067ce96cc79cd96c0928742979:
 
   asyncband/src/oneshot/mod.rs
   asyncband/src/oneshot/receiver.rs
   asyncband/src/oneshot/sender.rs
+
+Portions of the following test files and support are adapted from the same
+upstream test suite:
+
   asyncband/src/oneshot/tests.rs
   tests-integration/tests/oneshot_test/main.rs
+  tests-integration/tests/oneshot_test/support.rs
 
 The oneshot crate is available from https://github.com/faern/oneshot and is
-licensed under Apache-2.0 or MIT.
+licensed under Apache-2.0 or MIT. The corresponding upstream tests are:
+
+  https://github.com/faern/oneshot/blob/83fd0864be7289067ce96cc79cd96c0928742979/tests/async.rs
+  https://github.com/faern/oneshot/blob/83fd0864be7289067ce96cc79cd96c0928742979/tests/future.rs
+  https://github.com/faern/oneshot/blob/83fd0864be7289067ce96cc79cd96c0928742979/tests/miri.rs
+  https://github.com/faern/oneshot/blob/83fd0864be7289067ce96cc79cd96c0928742979/tests/sync.rs
+  https://github.com/faern/oneshot/tree/83fd0864be7289067ce96cc79cd96c0928742979/tests/helpers
 
 Portions of asyncband/src/internal/atomic_waker.rs are derived from futures-rs
 0.3.34 at commit 705e6b5c0f06535b1aac1cb1989a172b3d45be8c, available from

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@
 >
 > Apache Asyncband (incubating) is an effort undergoing incubation at the Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
 >
-> Please read the [DISCLAIMER](DISCLAIMER) and a full explanation of ["incubating"](https://incubator.apache.org/policy/incubation.html).
+> **Version 0.7.1 is an interim non-ASF release.** It has not been approved by the Apache Incubator PMC and is not an act of the ASF.
+>
+> Please read the [work-in-progress disclaimer](DISCLAIMER-WIP) and a full explanation of ["incubating"](https://incubator.apache.org/policy/incubation.html).
 >
 > **Asyncband was formerly published as MEA.** The `mea` crate is deprecated and receives no further development. See the [migration guide](MIGRATE.md) for migration instructions and details about the rename.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,14 @@ This runbook is for release managers. Follow the current [ASF Release Policy](ht
 
 The signed source archive approved by the Apache Incubator PMC and published through ASF distribution is the official Apache release. The crates.io package is a convenience distribution from the same approved commit. A signed `vX.Y.Z-rc.N` tag identifies the candidate; after the PPMC and IPMC votes pass, the voted artifacts move to the release distribution area and a signed `vX.Y.Z` tag on the same commit triggers crates.io publication.
 
+## Interim non-ASF 0.7.1 release
+
+Version 0.7.1 is a one-time interim non-ASF release. It is not approved by the Apache Incubator PMC, is not an act of the ASF, and must not be staged or published through ASF release infrastructure.
+
+Prepare 0.7.1 on `main`, retain `DISCLAIMER-WIP` in the Cargo package, and run the normal release checks against the exact release commit. Create and push a signed `v0.7.1` tag whose message identifies it as a non-ASF release; the release workflow validates the package but intentionally skips its crates.io publishing job for this tag. After that validation passes, publish the crate manually from a maintainer-controlled environment and verify crates.io and docs.rs. Do not upload 0.7.1 artifacts to ASF distribution or announce it as an Apache release.
+
+The next ASF release starts from a later version and follows the remainder of this runbook, including a fresh candidate and both release votes.
+
 ## Conventions
 
 - `VERSION` is the proposed final version, for example `0.7.0`.
@@ -57,7 +65,7 @@ Start from current `main` and choose `VERSION` from the changes since the latest
 
 1. Change `version` in `asyncband/Cargo.toml` and refresh `Cargo.lock` with Cargo.
 2. Move the entries under `Unreleased` in `CHANGELOG.md` into an undated `v${VERSION}` section immediately below it, then restore an empty `Unreleased` section. Keep user-impacting sections ordered as breaking changes, new features, bug fixes, and improvements; add the actual release date only after publication.
-3. Verify `LICENSE`, `NOTICE`, `DISCLAIMER`, source headers, and bundled dependencies.
+3. Verify `LICENSE`, `NOTICE`, the applicable `DISCLAIMER` or `DISCLAIMER-WIP`, source headers, and bundled dependencies.
 4. Run the release checks:
 
 ```shell

--- a/asyncband/Cargo.toml
+++ b/asyncband/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "asyncband"
-version = "0.7.0"
+version = "0.7.1"
 
 categories = ["asynchronous", "concurrency"]
 description = "Composable, runtime-agnostic concurrency building blocks for async Rust."

--- a/asyncband/DISCLAIMER
+++ b/asyncband/DISCLAIMER
@@ -1,1 +1,0 @@
-../DISCLAIMER

--- a/asyncband/DISCLAIMER-WIP
+++ b/asyncband/DISCLAIMER-WIP
@@ -1,0 +1,1 @@
+../DISCLAIMER-WIP

--- a/asyncband/src/blocking/parker.rs
+++ b/asyncband/src/blocking/parker.rs
@@ -1,20 +1,3 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
 // Adapted from parking 2.2.1 at commit 0ece32dbfd6cd1bc1510ede6ed56acb772edf83f:
 // https://github.com/smol-rs/parking/blob/0ece32dbfd6cd1bc1510ede6ed56acb772edf83f/src/lib.rs#L327-L429
 

--- a/asyncband/src/internal/atomic_waker.rs
+++ b/asyncband/src/internal/atomic_waker.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from futures-rs 0.3.34, with panic recovery informed by Tokio 1.53.1:
+// Portions derived from futures-rs 0.3.34, with panic recovery informed by Tokio 1.53.1:
 // https://github.com/rust-lang/futures-rs/blob/705e6b5c0f06535b1aac1cb1989a172b3d45be8c/futures-core/src/task/__internal/atomic_waker.rs
 // https://github.com/tokio-rs/tokio/blob/75fef53d0a8590c2d1dbb63672aa7b7d1ef51155/tokio/src/sync/task/atomic_waker.rs
 

--- a/asyncband/src/lib.rs
+++ b/asyncband/src/lib.rs
@@ -24,6 +24,11 @@
 //! reuse, and workload control without choosing an executor for the application. Its async APIs use
 //! standard futures and wakers, so they can run on Tokio, async-std, smol, or a custom executor.
 //!
+//! # Release status
+//!
+//! Version 0.7.1 is an interim non-ASF release. It has not been approved by the Apache Incubator
+//! PMC and is not an act of the Apache Software Foundation.
+//!
 //! # Getting started
 //!
 //! Public APIs are enabled through opt-in Cargo features, and no features are enabled by default.

--- a/asyncband/src/mutex/mod.rs
+++ b/asyncband/src/mutex/mod.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from Tokio 1.41.0:
+// Portions derived from Tokio 1.41.0:
 // https://github.com/tokio-rs/tokio/blob/01e04daaa162ce6122bb894fdda0b6803dd32093/tokio/src/sync/mutex.rs
 
 //! An async mutex for protecting shared data.

--- a/asyncband/src/oneshot/mod.rs
+++ b/asyncband/src/oneshot/mod.rs
@@ -15,7 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from the oneshot crate at commit 83fd0864:
+// Portions derived from the oneshot crate at commit
+// 83fd0864be7289067ce96cc79cd96c0928742979:
 // https://github.com/faern/oneshot/blob/83fd0864be7289067ce96cc79cd96c0928742979/src/lib.rs
 
 //! A one-shot channel is used for sending a single message between asynchronous tasks. The

--- a/asyncband/src/oneshot/receiver.rs
+++ b/asyncband/src/oneshot/receiver.rs
@@ -15,7 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from the oneshot crate at commit 83fd0864:
+// Portions derived from the oneshot crate at commit
+// 83fd0864be7289067ce96cc79cd96c0928742979:
 // https://github.com/faern/oneshot/blob/83fd0864be7289067ce96cc79cd96c0928742979/src/lib.rs
 
 use std::fmt;

--- a/asyncband/src/oneshot/sender.rs
+++ b/asyncband/src/oneshot/sender.rs
@@ -15,7 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from the oneshot crate at commit 83fd0864:
+// Portions derived from the oneshot crate at commit
+// 83fd0864be7289067ce96cc79cd96c0928742979:
 // https://github.com/faern/oneshot/blob/83fd0864be7289067ce96cc79cd96c0928742979/src/lib.rs
 
 use std::any::type_name;

--- a/asyncband/src/oneshot/tests.rs
+++ b/asyncband/src/oneshot/tests.rs
@@ -15,8 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from the oneshot crate at commit 83fd0864:
-// https://github.com/faern/oneshot/blob/83fd0864be7289067ce96cc79cd96c0928742979/src/lib.rs
+// Portions of the test support are adapted from the oneshot crate at commit
+// 83fd0864be7289067ce96cc79cd96c0928742979:
+// https://github.com/faern/oneshot/tree/83fd0864be7289067ce96cc79cd96c0928742979/tests/helpers
 
 use std::future::Future;
 use std::future::IntoFuture;

--- a/asyncband/src/rwlock/mapped_read_guard.rs
+++ b/asyncband/src/rwlock/mapped_read_guard.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from Tokio 1.42.0's RwLock implementation:
+// Portions derived from Tokio 1.42.0's RwLock implementation:
 // https://github.com/tokio-rs/tokio/tree/bb9d57017e100985f86d8ca41ac105ee9140423e/tokio/src/sync/rwlock
 
 use std::fmt;

--- a/asyncband/src/rwlock/mapped_write_guard.rs
+++ b/asyncband/src/rwlock/mapped_write_guard.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from Tokio 1.42.0's RwLock implementation:
+// Portions derived from Tokio 1.42.0's RwLock implementation:
 // https://github.com/tokio-rs/tokio/tree/bb9d57017e100985f86d8ca41ac105ee9140423e/tokio/src/sync/rwlock
 
 use std::fmt;

--- a/asyncband/src/rwlock/mod.rs
+++ b/asyncband/src/rwlock/mod.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from Tokio 1.42.0:
+// Portions derived from Tokio 1.42.0:
 // https://github.com/tokio-rs/tokio/blob/bb9d57017e100985f86d8ca41ac105ee9140423e/tokio/src/sync/rwlock.rs
 
 //! A reader-writer lock that allows multiple readers or a single writer at a time.

--- a/asyncband/src/rwlock/owned_mapped_read_guard.rs
+++ b/asyncband/src/rwlock/owned_mapped_read_guard.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from Tokio 1.42.0's RwLock implementation:
+// Portions derived from Tokio 1.42.0's RwLock implementation:
 // https://github.com/tokio-rs/tokio/tree/bb9d57017e100985f86d8ca41ac105ee9140423e/tokio/src/sync/rwlock
 
 use std::fmt;

--- a/asyncband/src/rwlock/owned_mapped_write_guard.rs
+++ b/asyncband/src/rwlock/owned_mapped_write_guard.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from Tokio 1.42.0's RwLock implementation:
+// Portions derived from Tokio 1.42.0's RwLock implementation:
 // https://github.com/tokio-rs/tokio/tree/bb9d57017e100985f86d8ca41ac105ee9140423e/tokio/src/sync/rwlock
 
 use std::fmt;

--- a/asyncband/src/rwlock/owned_read_guard.rs
+++ b/asyncband/src/rwlock/owned_read_guard.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from Tokio 1.42.0's RwLock implementation:
+// Portions derived from Tokio 1.42.0's RwLock implementation:
 // https://github.com/tokio-rs/tokio/tree/bb9d57017e100985f86d8ca41ac105ee9140423e/tokio/src/sync/rwlock
 
 use std::fmt;

--- a/asyncband/src/rwlock/owned_write_guard.rs
+++ b/asyncband/src/rwlock/owned_write_guard.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from Tokio 1.42.0's RwLock implementation:
+// Portions derived from Tokio 1.42.0's RwLock implementation:
 // https://github.com/tokio-rs/tokio/tree/bb9d57017e100985f86d8ca41ac105ee9140423e/tokio/src/sync/rwlock
 
 use std::fmt;

--- a/asyncband/src/rwlock/read_guard.rs
+++ b/asyncband/src/rwlock/read_guard.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from Tokio 1.42.0's RwLock implementation:
+// Portions derived from Tokio 1.42.0's RwLock implementation:
 // https://github.com/tokio-rs/tokio/tree/bb9d57017e100985f86d8ca41ac105ee9140423e/tokio/src/sync/rwlock
 
 use std::fmt;

--- a/asyncband/src/rwlock/write_guard.rs
+++ b/asyncband/src/rwlock/write_guard.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from Tokio 1.42.0's RwLock implementation:
+// Portions derived from Tokio 1.42.0's RwLock implementation:
 // https://github.com/tokio-rs/tokio/tree/bb9d57017e100985f86d8ca41ac105ee9140423e/tokio/src/sync/rwlock
 
 use std::fmt;

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -19,4 +19,6 @@
 builtin = "Apache-2.0-ASF"
 
 [files]
+# This adapted third-party source intentionally does not carry the ASF source header.
+excludes = ["asyncband/src/blocking/parker.rs"]
 includes = ["**/*.proto", "**/*.rs", "**/*.yml", "**/*.yaml", "**/*.toml"]

--- a/tests-integration/tests/oneshot_test/main.rs
+++ b/tests-integration/tests/oneshot_test/main.rs
@@ -15,8 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Derived from the oneshot crate at commit 83fd0864:
-// https://github.com/faern/oneshot/blob/83fd0864be7289067ce96cc79cd96c0928742979/src/lib.rs
+// Portions of these tests are adapted from the oneshot crate at commit
+// 83fd0864be7289067ce96cc79cd96c0928742979:
+// https://github.com/faern/oneshot/blob/83fd0864be7289067ce96cc79cd96c0928742979/tests/async.rs
+// https://github.com/faern/oneshot/blob/83fd0864be7289067ce96cc79cd96c0928742979/tests/future.rs
+// https://github.com/faern/oneshot/blob/83fd0864be7289067ce96cc79cd96c0928742979/tests/miri.rs
+// https://github.com/faern/oneshot/blob/83fd0864be7289067ce96cc79cd96c0928742979/tests/sync.rs
 
 use std::future::Future;
 use std::future::IntoFuture;

--- a/tests-integration/tests/oneshot_test/support.rs
+++ b/tests-integration/tests/oneshot_test/support.rs
@@ -15,6 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// Portions of this test support are adapted from the oneshot crate at commit
+// 83fd0864be7289067ce96cc79cd96c0928742979:
+// https://github.com/faern/oneshot/tree/83fd0864be7289067ce96cc79cd96c0928742979/tests/helpers
+
 use std::hint::spin_loop;
 use std::sync::Arc;
 use std::sync::atomic::AtomicU32;


### PR DESCRIPTION
## Summary

- correct derived-source header treatment and make third-party implementation and test provenance precise
- prepare version 0.7.1 and identify it in the packaged README, rustdoc, changelog, and DISCLAIMER-WIP as an interim non-ASF release
- keep v0.7.1 outside ASF release infrastructure by skipping trusted publishing for that tag and documenting the manual crates.io path

## Design Notes

Version 0.7.0 has already been published. Version 0.7.1 is intentionally a non-ASF release: it is not approved by the Apache Incubator PMC, must not be staged on ASF distribution, and will be published manually after the signed tag passes package validation.

## Validation

- cargo x lint
- cargo x check
- cargo x test --no-capture
- RUSTUP_TOOLCHAIN=1.86.0 cargo x test --no-capture
- cargo x semver --release-version 0.7.1 --acknowledge-breaking-changes
- cargo publish --package asyncband --locked --dry-run
- inspected the 71-file package list and confirmed DISCLAIMER-WIP is included
