### PR TITLE
chore: prepare ASF 0.7.2 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,8 +112,7 @@ jobs:
 
   publish:
     name: Publish to crates.io
-    # v0.7.1 is an interim non-ASF release published outside ASF release infrastructure.
-    if: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name != 'v0.7.1' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
     needs: check
     runs-on: ubuntu-24.04
     timeout-minutes: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## v0.7.2
+
 ### Improvements
 
 * Preserve applicable third-party licensing and copyright notices on derived source files, and record exact provenance mappings and design acknowledgements in `LICENSE` and source comments.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "asyncband"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "hashbrown",
  "tokio",

--- a/DISCLAIMER
+++ b/DISCLAIMER
@@ -1,0 +1,5 @@
+Apache Asyncband (Incubating) is an effort undergoing incubation at the Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+
+Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects.
+
+While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.

--- a/DISCLAIMER-WIP
+++ b/DISCLAIMER-WIP
@@ -1,8 +1,0 @@
-Apache Asyncband is an effort undergoing incubation at The Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC. Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision-making process have stabilized in a manner consistent with other successful ASF projects. While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
-
-Some of the incubating project's releases may not be fully compliant with ASF policy. The following issues are known for version 0.7.1:
-
-- Version 0.7.1 is an interim non-ASF release. It has not been approved by the Apache Incubator PMC and is not an act of the ASF.
-- The third-party provenance and source-header corrections included in version 0.7.1 have not been reviewed or approved through an ASF release vote.
-
-If you are planning to incorporate this work into your product or project, please conduct a thorough licensing review to determine the overall implications of including it. For the current status of Apache Asyncband in the Apache Incubator, visit https://incubator.apache.org/projects/asyncband.html.

--- a/README.md
+++ b/README.md
@@ -20,9 +20,7 @@
 >
 > Apache Asyncband (incubating) is an effort undergoing incubation at the Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
 >
-> **Version 0.7.1 is an interim non-ASF release.** It has not been approved by the Apache Incubator PMC and is not an act of the ASF.
->
-> Please read the [work-in-progress disclaimer](DISCLAIMER-WIP) and a full explanation of ["incubating"](https://incubator.apache.org/policy/incubation.html).
+> Please read the [DISCLAIMER](DISCLAIMER) and a full explanation of ["incubating"](https://incubator.apache.org/policy/incubation.html).
 >
 > **Asyncband was formerly published as MEA.** The `mea` crate is deprecated and receives no further development. See the [migration guide](MIGRATE.md) for migration instructions and details about the rename.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,17 +4,9 @@ This runbook is for release managers. Follow the current [ASF Release Policy](ht
 
 The signed source archive approved by the Apache Incubator PMC and published through ASF distribution is the official Apache release. The crates.io package is a convenience distribution from the same approved commit. A signed `vX.Y.Z-rc.N` tag identifies the candidate; after the PPMC and IPMC votes pass, the voted artifacts move to the release distribution area and a signed `vX.Y.Z` tag on the same commit triggers crates.io publication.
 
-## Interim non-ASF 0.7.1 release
-
-Version 0.7.1 is a one-time interim non-ASF release. It is not approved by the Apache Incubator PMC, is not an act of the ASF, and must not be staged or published through ASF release infrastructure.
-
-Prepare 0.7.1 on `main`, retain `DISCLAIMER-WIP` in the Cargo package, and run the normal release checks against the exact release commit. Create and push a signed `v0.7.1` tag whose message identifies it as a non-ASF release; the release workflow validates the package but intentionally skips its crates.io publishing job for this tag. After that validation passes, publish the crate manually from a maintainer-controlled environment and verify crates.io and docs.rs. Do not upload 0.7.1 artifacts to ASF distribution or announce it as an Apache release.
-
-The next ASF release starts from a later version and follows the remainder of this runbook, including a fresh candidate and both release votes.
-
 ## Conventions
 
-- `VERSION` is the proposed final version, for example `0.7.0`.
+- `VERSION` is the proposed final version, for example `0.7.2`.
 - `RC` is the positive candidate number, for example `1`.
 - `RELEASE_COMMIT` is the merged release pull request commit used for every candidate artifact and release tag.
 - The source archive is `apache-asyncband-${VERSION}-incubating-src.tar.gz`; the RC number appears in the staging directory and tag.
@@ -65,7 +57,7 @@ Start from current `main` and choose `VERSION` from the changes since the latest
 
 1. Change `version` in `asyncband/Cargo.toml` and refresh `Cargo.lock` with Cargo.
 2. Move the entries under `Unreleased` in `CHANGELOG.md` into an undated `v${VERSION}` section immediately below it, then restore an empty `Unreleased` section. Keep user-impacting sections ordered as breaking changes, new features, bug fixes, and improvements; add the actual release date only after publication.
-3. Verify `LICENSE`, `NOTICE`, the applicable `DISCLAIMER` or `DISCLAIMER-WIP`, source headers, and bundled dependencies.
+3. Verify `LICENSE`, `NOTICE`, `DISCLAIMER`, source headers, and bundled dependencies.
 4. Run the release checks:
 
 ```shell

--- a/asyncband/Cargo.toml
+++ b/asyncband/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "asyncband"
-version = "0.7.1"
+version = "0.7.2"
 
 categories = ["asynchronous", "concurrency"]
 description = "Composable, runtime-agnostic concurrency building blocks for async Rust."

--- a/asyncband/DISCLAIMER
+++ b/asyncband/DISCLAIMER
@@ -1,0 +1,1 @@
+../DISCLAIMER

--- a/asyncband/DISCLAIMER-WIP
+++ b/asyncband/DISCLAIMER-WIP
@@ -1,1 +1,0 @@
-../DISCLAIMER-WIP

--- a/asyncband/src/lib.rs
+++ b/asyncband/src/lib.rs
@@ -24,11 +24,6 @@
 //! reuse, and workload control without choosing an executor for the application. Its async APIs use
 //! standard futures and wakers, so they can run on Tokio, async-std, smol, or a custom executor.
 //!
-//! # Release status
-//!
-//! Version 0.7.1 is an interim non-ASF release. It has not been approved by the Apache Incubator
-//! PMC and is not an act of the Apache Software Foundation.
-//!
 //! # Getting started
 //!
 //! Public APIs are enabled through opt-in Cargo features, and no features are enabled by default.


### PR DESCRIPTION
## Summary

- bump the crate and lockfile version to 0.7.2 and move the pending licensing improvement into the 0.7.2 changelog section
- restore the standard Incubator `DISCLAIMER` in the repository and packaged crate, replacing `DISCLAIMER-WIP`
- remove the 0.7.1 interim non-ASF notices and release-runbook exception while retaining its historical changelog record
- restore tagged crates.io publication through the ASF release workflow

## Design Notes

Version 0.7.2 is prepared for the normal Incubator release process: signed source candidate, PPMC and IPMC votes, ASF distribution, and final convenience publication from the approved commit. The 0.7.1 changelog note remains because it records the status of that already-published version; it no longer controls current documentation or automation.

## Validation

- `cargo x check`
- `cargo x test --no-capture`
- `RUSTUP_TOOLCHAIN=1.86.0 cargo x test --no-capture`
- `cargo x semver --release-version 0.7.2`
- `cargo publish --package asyncband --locked --dry-run`
- Clippy, rustfmt, typos, and Hawkeye
- verified `cargo package --package asyncband --allow-dirty --list` contains `DISCLAIMER` and not `DISCLAIMER-WIP`

`cargo x lint` reaches and passes Clippy and rustfmt, then Taplo 0.10.0 panics locally while initializing the macOS system proxy configuration; CI will run the same formatting check independently.
