### PR TITLE
fix: keep release candidates off crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,6 @@ jobs:
     timeout-minutes: 30
     outputs:
       version: ${{ steps.package.outputs.version }}
-      publish_version: ${{ steps.package.outputs.publish_version }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -60,12 +59,7 @@ jobs:
             echo "The asyncband package version must be a stable X.Y.Z version, got: ${version}" >&2
             exit 1
           fi
-          publish_version="${version}"
-          if [[ "${GITHUB_REF_NAME}" == "v${version}-rc."* ]]; then
-            publish_version="${GITHUB_REF_NAME#v}"
-          fi
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
-          echo "publish_version=${publish_version}" >> "${GITHUB_OUTPUT}"
       - name: Check tag
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         shell: bash
@@ -93,22 +87,8 @@ jobs:
             echo "Release tag ${GITHUB_REF_NAME} does not point to a commit on main." >&2
             exit 1
           fi
-      - name: Prepare crates.io release candidate
-        if: ${{ steps.package.outputs.publish_version != steps.package.outputs.version }}
-        shell: bash
-        env:
-          PACKAGE_VERSION: ${{ steps.package.outputs.version }}
-          PUBLISH_VERSION: ${{ steps.package.outputs.publish_version }}
-        run: |
-          perl -pi -e 's/^version = "\Q$ENV{PACKAGE_VERSION}\E"$/version = "$ENV{PUBLISH_VERSION}"/' asyncband/Cargo.toml
-          grep -Fx "version = \"${PUBLISH_VERSION}\"" asyncband/Cargo.toml
-          cargo check --package asyncband
       - name: Check crates.io package
-        if: ${{ steps.package.outputs.publish_version == steps.package.outputs.version }}
         run: cargo publish --package asyncband --locked --dry-run
-      - name: Check crates.io release candidate
-        if: ${{ steps.package.outputs.publish_version != steps.package.outputs.version }}
-        run: cargo publish --package asyncband --locked --dry-run --allow-dirty
 
   publish:
     name: Publish to crates.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,8 @@ jobs:
 
   publish:
     name: Publish to crates.io
-    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    # Only the final tag approved through the ASF release vote may publish to crates.io.
+    if: ${{ github.ref == format('refs/tags/v{0}', needs.check.outputs.version) }}
     needs: check
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -127,22 +128,10 @@ jobs:
           rustup toolchain install stable
           --profile minimal
           --no-self-update
-      - name: Prepare crates.io release candidate
-        if: ${{ needs.check.outputs.publish_version != needs.check.outputs.version }}
-        shell: bash
-        env:
-          PACKAGE_VERSION: ${{ needs.check.outputs.version }}
-          PUBLISH_VERSION: ${{ needs.check.outputs.publish_version }}
-        run: |
-          perl -pi -e 's/^version = "\Q$ENV{PACKAGE_VERSION}\E"$/version = "$ENV{PUBLISH_VERSION}"/' asyncband/Cargo.toml
-          grep -Fx "version = \"${PUBLISH_VERSION}\"" asyncband/Cargo.toml
-          cargo check --package asyncband
       - id: auth
         name: Authenticate with crates.io
         uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
       - name: Publish asyncband
-        run: >-
-          cargo publish --package asyncband --locked
-          ${{ needs.check.outputs.publish_version != needs.check.outputs.version && '--allow-dirty' || '' }}
+        run: cargo publish --package asyncband --locked
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 * Preserve applicable third-party licensing and copyright notices on derived source files, and record exact provenance mappings in `LICENSE` and source comments.
 
-## v0.7.1
+## v0.7.1 - 2026-09-04
 
 This is an interim non-ASF release. It has not been approved by the Apache Incubator PMC and is not an act of the Apache Software Foundation.
 
@@ -18,7 +18,9 @@ This is an interim non-ASF release. It has not been approved by the Apache Incub
 
 * Correct source-header treatment and make third-party derivation and test provenance records more precise in source distributions.
 
-## v0.7.0
+## v0.7.0 - 2026-09-04
+
+This non-ASF release was not approved by the Apache Incubator PMC, is not an act of the Apache Software Foundation, and has been yanked from crates.io.
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 * Preserve applicable third-party licensing and copyright notices on derived source files, and record exact provenance mappings in `LICENSE` and source comments.
 
-## v0.7.1 - 2026-09-04
+## v0.7.1 (2026-09-04)
 
 This is an interim non-ASF release. It has not been approved by the Apache Incubator PMC and is not an act of the Apache Software Foundation.
 
@@ -18,7 +18,7 @@ This is an interim non-ASF release. It has not been approved by the Apache Incub
 
 * Correct source-header treatment and make third-party derivation and test provenance records more precise in source distributions.
 
-## v0.7.0 - 2026-09-04
+## v0.7.0 (2026-09-04)
 
 This non-ASF release was not approved by the Apache Incubator PMC, is not an act of the Apache Software Foundation, and has been yanked from crates.io.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -94,7 +94,7 @@ git tag --sign "${RC_TAG}" \
 git push https://github.com/apache/asyncband.git "${RC_TAG}"
 ```
 
-Wait for the `Release` GitHub Actions workflow to pass. The workflow validates a convenience prerelease package named `${VERSION}-rc.${RC}` with `cargo publish --dry-run` but does not publish it to crates.io. A candidate that needs a code change gets a new release pull request, merge commit, RC number, and signed tag.
+Wait for the `Release` GitHub Actions workflow to pass. The workflow validates the RC tag and runs `cargo publish --dry-run` against the unchanged `${VERSION}` package; it skips the crates.io publish job for RC tags. A candidate that needs a code change gets a new release pull request, merge commit, RC number, and signed tag.
 
 ## 3. Build and verify the source archive
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -94,7 +94,7 @@ git tag --sign "${RC_TAG}" \
 git push https://github.com/apache/asyncband.git "${RC_TAG}"
 ```
 
-Wait for the `Release` GitHub Actions workflow to pass. The workflow publishes a convenience prerelease named `${VERSION}-rc.${RC}` to crates.io while the source tag and release candidate retain the stable `${VERSION}` package version. A candidate that needs a code change gets a new release pull request, merge commit, RC number, and signed tag.
+Wait for the `Release` GitHub Actions workflow to pass. The workflow validates a convenience prerelease package named `${VERSION}-rc.${RC}` with `cargo publish --dry-run` but does not publish it to crates.io. A candidate that needs a code change gets a new release pull request, merge commit, RC number, and signed tag.
 
 ## 3. Build and verify the source archive
 


### PR DESCRIPTION
## Summary

- Prevent release-candidate tags and manual workflow runs from publishing unapproved packages to crates.io; RC tags validate the unchanged final-version package with `cargo publish --dry-run`.
- Remove the synthetic `${VERSION}-rc.${RC}` Cargo version, manifest rewrite, and `--allow-dirty` path from the release workflow and runbook.
- Add the 2026-09-04 dates for v0.7.0 and v0.7.1, and record that v0.7.0 was a yanked non-ASF release.

## Design Notes

ASF release candidates are identified by the signed RC tag and the ASF staging directory, not by a separately versioned crate. The publish job runs only when the pushed ref exactly matches the final `v${VERSION}` tag produced after the release votes.

## Validation

- `cargo x check`
- `cargo x test --no-capture`
- `RUSTUP_TOOLCHAIN=1.86.0 cargo x test --no-capture`
- `cargo x semver --release-version 0.7.2`
- `cargo publish --package asyncband --locked --dry-run`
- `RUSTDOCFLAGS="-D warnings --cfg docsrs" cargo +nightly doc --workspace --all-features --no-deps`
- `typos`
- `hawkeye check`
- Release workflow YAML parse and `git diff --check`

`cargo x lint` passed Clippy and rustfmt before the local Taplo 0.10.0 process hit its known macOS `system-configuration` NULL-object panic; the remaining lint checks were run separately as listed above.
