### PR TITLE
perf(mpsc): streamline unbounded buffer reclamation

### DIFF
--- a/asyncband/src/mpsc/unbounded/buffer.rs
+++ b/asyncband/src/mpsc/unbounded/buffer.rs
@@ -53,16 +53,28 @@ impl<T> Buffer<T> {
         self.writable.push_back(value);
     }
 
-    pub fn refill(&mut self, batch: &mut VecDeque<T>) {
+    /// Returns retired allocations so the receiver can release them after unlocking.
+    #[must_use = "retired allocations must be dropped after releasing the shared lock"]
+    pub fn refill(
+        &mut self,
+        batch: &mut VecDeque<T>,
+    ) -> Option<(VecDeque<T>, VecDeque<VecDeque<T>>)> {
         debug_assert!(batch.is_empty());
         if let Some(sealed) = self.sealed.pop_front() {
-            *batch = sealed;
-            if self.sealed.is_empty() && self.sealed.capacity() * size_of::<VecDeque<T>>() > 1024 {
-                self.sealed = VecDeque::new();
-            }
-        } else if !self.writable.is_empty() {
+            let retired_batch = mem::replace(batch, sealed);
+            let retired_sealed = if self.sealed.is_empty()
+                && self.sealed.capacity() * size_of::<VecDeque<T>>() > 1024
+            {
+                mem::take(&mut self.sealed)
+            } else {
+                VecDeque::new()
+            };
+            return Some((retired_batch, retired_sealed));
+        }
+        if !self.writable.is_empty() {
             mem::swap(batch, &mut self.writable);
         }
+        None
     }
 }
 
@@ -94,7 +106,7 @@ mod tests {
 
     fn receive<T>(buffer: &mut Buffer<T>, batch: &mut VecDeque<T>) -> T {
         if batch.is_empty() {
-            buffer.refill(batch);
+            drop(buffer.refill(batch));
         }
         pop_batch(batch)
     }
@@ -117,7 +129,7 @@ mod tests {
             assert_eq!(receive(&mut buffer, &mut batch), [value; 128]);
         }
         assert!(allocated_bytes(&buffer, &batch) <= 2 * SEGMENT_BYTES);
-        buffer.refill(&mut batch);
+        drop(buffer.refill(&mut batch));
         assert!(batch.is_empty());
     }
 

--- a/asyncband/src/mpsc/unbounded/buffer.rs
+++ b/asyncband/src/mpsc/unbounded/buffer.rs
@@ -21,6 +21,7 @@ use std::mem;
 // Bound the inline storage retained by a partial batch. Boxed payloads belong to individual
 // messages, not these backing allocations. Empty buffers are reused without retaining peak size.
 pub const SEGMENT_BYTES: usize = 32 * 1024;
+const RETAINED_DIRECTORY_BYTES: usize = 1024;
 
 pub struct Buffer<T> {
     writable: VecDeque<T>,
@@ -28,6 +29,19 @@ pub struct Buffer<T> {
 }
 
 impl<T> Buffer<T> {
+    const SEGMENT_CAPACITY: usize = if size_of::<T>() == 0 {
+        usize::MAX
+    } else if size_of::<T>() > SEGMENT_BYTES {
+        1
+    } else {
+        let limit = SEGMENT_BYTES / size_of::<T>();
+        // Power-of-two limits keep ordinary VecDeque growth within the segment byte budget.
+        1 << (usize::BITS - 1 - limit.leading_zeros())
+    };
+
+    // The empty directory retains segment headers, not message storage.
+    const RETAINED_DIRECTORY_SLOTS: usize = RETAINED_DIRECTORY_BYTES / size_of::<VecDeque<T>>();
+
     pub fn new() -> Self {
         Self {
             writable: VecDeque::new(),
@@ -35,18 +49,9 @@ impl<T> Buffer<T> {
         }
     }
 
-    fn segment_capacity() -> usize {
-        if size_of::<T>() == 0 {
-            return usize::MAX;
-        }
-        let limit = (SEGMENT_BYTES / size_of::<T>()).max(1);
-        // Power-of-two limits let VecDeque grow naturally without exceeding the segment budget.
-        1 << (usize::BITS - 1 - limit.leading_zeros())
-    }
-
     pub fn push(&mut self, value: T) {
-        if self.writable.len() == Self::segment_capacity() {
-            let next = VecDeque::with_capacity(Self::segment_capacity());
+        if self.writable.len() == Self::SEGMENT_CAPACITY {
+            let next = VecDeque::with_capacity(Self::SEGMENT_CAPACITY);
             let sealed = mem::replace(&mut self.writable, next);
             self.sealed.push_back(sealed);
         }
@@ -63,7 +68,7 @@ impl<T> Buffer<T> {
         if let Some(sealed) = self.sealed.pop_front() {
             let retired_batch = mem::replace(batch, sealed);
             let retired_sealed = if self.sealed.is_empty()
-                && self.sealed.capacity() * size_of::<VecDeque<T>>() > 1024
+                && self.sealed.capacity() > Self::RETAINED_DIRECTORY_SLOTS
             {
                 mem::take(&mut self.sealed)
             } else {
@@ -79,9 +84,11 @@ impl<T> Buffer<T> {
 }
 
 pub fn pop_batch<T>(batch: &mut VecDeque<T>) -> T {
-    if batch.len() == 1 && batch.capacity().saturating_mul(size_of::<T>()) > SEGMENT_BYTES {
-        // Retire the allocation on the last value, outside the shared lock. Keep this as a tail
-        // expression to avoid intermediate storage for large inline values.
+    if size_of::<T>() > SEGMENT_BYTES {
+        // Ordinary segments stay within the byte budget and reuse their empty allocation.
+        // Oversized values occupy one slot per segment, so consuming one retires its allocation.
+        debug_assert_eq!(batch.len(), 1);
+        // Keep this as a tail expression to avoid intermediate storage for large inline values.
         mem::take(batch).pop_front()
     } else {
         batch.pop_front()
@@ -131,6 +138,35 @@ mod tests {
         assert!(allocated_bytes(&buffer, &batch) <= 2 * SEGMENT_BYTES);
         drop(buffer.refill(&mut batch));
         assert!(batch.is_empty());
+    }
+
+    #[test]
+    fn ordinary_segments_stay_within_the_byte_budget_across_refills() {
+        fn check<const SIZE: usize>() {
+            let mut buffer = Buffer::new();
+            let mut batch = VecDeque::new();
+            let messages = SEGMENT_BYTES / SIZE + 2;
+            for _ in 0..2 {
+                for value in 0..messages {
+                    buffer.push([value as u8; SIZE]);
+                    for segment in std::iter::once(&buffer.writable).chain(&buffer.sealed) {
+                        assert!(segment.capacity() * SIZE <= SEGMENT_BYTES);
+                    }
+                }
+                for value in 0..messages {
+                    assert_eq!(receive(&mut buffer, &mut batch), [value as u8; SIZE]);
+                    assert!(batch.capacity() * SIZE <= SEGMENT_BYTES);
+                }
+            }
+        }
+
+        // Exercise VecDeque's initial growth and segment rounding around payload-size boundaries.
+        check::<1023>();
+        check::<1024>();
+        check::<1025>();
+        check::<{ SEGMENT_BYTES / 2 }>();
+        check::<{ SEGMENT_BYTES / 2 + 1 }>();
+        check::<SEGMENT_BYTES>();
     }
 
     #[test]

--- a/asyncband/src/mpsc/unbounded/receiver.rs
+++ b/asyncband/src/mpsc/unbounded/receiver.rs
@@ -96,9 +96,12 @@ impl<T> UnboundedReceiver<T> {
         let batch = self.batch.get_mut();
         if batch.is_empty() {
             let mut state = self.shared.lock();
-            state.buffer.refill(batch);
+            let retired = state.buffer.refill(batch);
+            let disconnected = state.senders == 0;
+            drop(state);
+            drop(retired);
             if batch.is_empty() {
-                return Err(if state.senders == 0 {
+                return Err(if disconnected {
                     TryRecvError::Disconnected
                 } else {
                     TryRecvError::Empty
@@ -149,19 +152,22 @@ impl<T> UnboundedReceiver<T> {
         // Waker clone/drop callbacks can send into this channel, so run them outside the lock.
         let waker = cx.waker().clone();
         let mut state = self.shared.lock();
-        state.buffer.refill(batch);
+        let retired = state.buffer.refill(batch);
         if !batch.is_empty() {
             drop(state);
+            drop(retired);
             return Poll::Ready(Ok(pop_batch(batch)));
         }
         if state.senders == 0 {
             let old = state.recv_waker.take();
             drop(state);
+            drop(retired);
             drop(old);
             return Poll::Ready(Err(RecvError::Disconnected));
         }
         let old = state.recv_waker.replace(waker);
         drop(state);
+        drop(retired);
         drop(old);
         Poll::Pending
     }


### PR DESCRIPTION
## Summary

Unbounded receiver refills currently release retired batch allocations and oversized empty segment directories while holding the shared state mutex. Receiving also checks the last message and allocation capacity even for payload types whose segments cannot exceed the byte budget. Release retired storage after unlocking, and select oversized-payload reclamation at compile time so ordinary messages use the normal local pop path.

Make segment capacity and the retained directory's slot limit associated constants, with a named directory byte budget. Power-of-two growth keeps ordinary segments within 32 KiB; oversized payloads use one slot and release their backing allocation when consumed. A focused boundary test checks that growth, sealing, and buffer reuse preserve the capacity invariant around payload-size thresholds.

Validated with `cargo x test` on the default nightly and Rust 1.86.0, `cargo x lint --fix`, `cargo x check`, `cargo x bench --no-run`, and the full `cargo x miri` workflow. Benchmark adapters, extra measurement cases, and raw results are outside the repository.

Benchmarks compare main `7ad6d68d45a3b74506d9a605e594c417e80d506b` with the final implementation in the same executable on an Apple M4 Max, macOS 26.6.2, rustc 1.99.0-nightly (3d6c19bb9). Values are medians of ten round medians, with randomized implementation order, 100 samples per case, 1,000 iterations per microbenchmark sample, and one batch per throughput sample. Coverage includes all 21 existing unbounded workloads, two 4,096-message inline bursts, and a 32-message burst of 64 KiB payloads. Async workloads transfer 16,384 messages per sample; inline async bursts use four runtime workers.

| Workload | Main | This PR | Elapsed change |
| --- | ---: | ---: | ---: |
| Try round trip | 10.9350 ns | 10.4600 ns | -4.3% |
| Sequential 64 B inline, 1,024 messages | 10.4100 µs | 8.1970 µs | -21.3% |
| Sequential 1 KiB inline, 1,024 messages | 65.6400 µs | 56.6300 µs | -13.7% |
| Sequential 1 KiB inline, 4,096 messages | 265.1500 µs | 226.6500 µs | -14.5% |
| Sequential boxed 1 KiB, 1,024 messages | 55.0900 µs | 53.2400 µs | -3.4% |
| Sequential 64 KiB inline, 32 messages | 158.3000 µs | 111.5000 µs | -29.6% |
| Async 1 KiB, 1 producer, 1,024-message bursts | 1.7685 ms | 1.3835 ms | -21.8% |
| Async 1 KiB, 8 producers, 1,024-message bursts | 3.2125 ms | 3.1105 ms | -3.2% |
| Native threads, 8 producers, 16,384 messages | 360.7000 µs | 360.5500 µs | -0.0% |
| Sequential usize, 1,024 messages, retained backlog | 8.3330 µs | 8.3740 µs | +0.5% |

The sequential inline/boxed payload improvements occur in all ten paired rounds. Most usize throughput workloads remain close to main; the largest measured increase versus main is 0.5% in the 1,024-message retained-backlog case. These are workload-specific measurements on this machine, not a claim of uniform improvement across platforms.
