### PR TITLE
ci: use HawkEye 7.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - uses: taiki-e/install-action@84f5ac3124727fb3d284d4d22ee9ab3654fd09a6 # v2.87.7
         with:
-          tool: typos-cli,taplo-cli,hawkeye@7.2.0
+          tool: typos-cli,taplo-cli,hawkeye
       - run: cargo x lint
       - name: Check feature matrix
         run: cargo x check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - uses: taiki-e/install-action@84f5ac3124727fb3d284d4d22ee9ab3654fd09a6 # v2.87.7
         with:
-          tool: typos-cli,taplo-cli,hawkeye
+          tool: typos-cli,taplo-cli,hawkeye@7.2.0
       - run: cargo x lint
       - name: Check feature matrix
         run: cargo x check

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -20,10 +20,6 @@ builtin = "Apache-2.0-ASF"
 
 [files]
 excludes = [
-  # Skill discovery requires YAML frontmatter first. Its ASF header follows the frontmatter,
-  # which HawkEye currently cannot skip when checking or inserting headers.
-  ".agents/skills/license-audit/SKILL.md",
-  ".agents/skills/release/SKILL.md",
   # These third-party-derived files retain the applicable upstream license and copyright notices.
   "asyncband/src/blocking/executor.rs",
   "asyncband/src/blocking/parker.rs",


### PR DESCRIPTION
## Summary

Pin HawkEye to 7.2.0 in CI and remove the skill documents' license-header exclusions now that YAML frontmatter is supported.

Validated with `cargo x lint` and repeated `hawkeye format` runs on both skill documents; their contents remain byte-for-byte unchanged.
